### PR TITLE
Feature/game update

### DIFF
--- a/.github/instructions/repository-information.instructions.md
+++ b/.github/instructions/repository-information.instructions.md
@@ -14,13 +14,16 @@ Key repository information:
 - Projects:
   - `source/Lexicala.NET/` — main library project with the Lexicala client, configuration, parsing, request, and response types
   - `source/Demo/Lexicala.NET.Demo.Api/` — ASP.NET Core host with Swagger UI for manually exercising the implemented Lexicala endpoints
+  - `source/Demo/sense-sprint-web/` — React + TypeScript + Vite demo game that lives alongside the API demo under `source/Demo/`
   - `source/Lexicala.NET.Tests/` — unit tests and parser tests with embedded JSON fixtures under `Resources/`
 - Target frameworks:
   - `source/Lexicala.NET/` — `net8.0` and `net10.0`
   - `source/Demo/Lexicala.NET.Demo.Api/` — `net10.0`
+  - `source/Demo/sense-sprint-web/` — Vite/TypeScript React application
   - `source/Lexicala.NET.Tests/` — `net10.0`
-- Purpose: provides a .NET SDK for interacting with the Lexicala API, including request models, response models, parser/search abstractions, dependency registration, and a Swagger-enabled local test host.
+- Purpose: provides a .NET SDK for interacting with the Lexicala API, including request models, response models, parser/search abstractions, dependency registration, and demo experiences under `source/Demo/` for both a Swagger-enabled API host and the Sense Sprint web game.
 - Repository is organized into:
+  - `Demo/` for runnable demonstrations, including the ASP.NET Core API host and the Sense Sprint web demo game
   - `Parsing/` for search parser implementation and DTO models
   - `Request/` for request model definitions
   - `Response/` for response model definitions and metadata

--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ For React frontend development, CORS is enabled for:
 
 A dedicated React + Vite frontend for a word guessing game is available at `source/Demo/sense-sprint-web`.
 
+The web demo currently includes two game modes. `Sense Sprint` is the lower-cost mode. `Translation Quiz` makes more Lexicala calls per round because it has to source a word, fetch its entry, and build multiple distractor choices. If you are using a free evaluation subscription, use Translation Quiz sparingly.
+
 1. Start the backend API (see Testing with Swagger UI above)
 
 2. In another terminal, navigate to the frontend:

--- a/README.md
+++ b/README.md
@@ -203,7 +203,28 @@ The repository includes an ASP.NET Core minimal Web API demo host with Swagger U
    cd source/Demo/Lexicala.NET.Demo.Api
    ```
 
-2. Run the application:
+2. Configure your Lexicala API key. Choose one of the following:
+
+   **Recommended: Use User Secrets**
+
+   ```bash
+   dotnet user-secrets init
+   dotnet user-secrets set "Lexicala:ApiKey" "your-rapidapi-key-here"
+   ```
+
+   **Alternative: Edit appsettings.json**
+
+   Open `appsettings.json` in the demo API folder and add:
+
+   ```json
+   {
+     "Lexicala": {
+       "ApiKey": "your-rapidapi-key-here"
+     }
+   }
+   ```
+
+3. Run the application:
 
    ```bash
    dotnet run
@@ -213,9 +234,7 @@ The repository includes an ASP.NET Core minimal Web API demo host with Swagger U
    - HTTP: `http://localhost:5000/swagger`
    - HTTPS: `https://localhost:5001/swagger`
 
-4. Test the endpoints directly in the UI.
-
-5. To use the Sense Sprint web app, run the dedicated frontend described in the "Sense Sprint Frontend (Vite + React)" section below.
+5. To use the Sense Sprint web app, see the [Sense Sprint documentation](https://github.com/HannoZ/Lexicala.NET/blob/main/source/Demo/sense-sprint-web/README.md) for setup and gameplay details.
 
 Available endpoints:
 
@@ -232,7 +251,7 @@ Available endpoints:
 - `POST /search-advanced` - Advanced search
 - `POST /search-entries-advanced` - Advanced search with full entries
 - `POST /search-rdf-advanced` - Advanced search in RDF/JSON-LD format
-- `POST /game/sense-sprint/rounds` - Create a new Sense Sprint round (word sourced from Fluky Search, language fixed to English)
+- `POST /game/sense-sprint/rounds` - Create a new Sense Sprint round (word sourced from Fluky Search in the selected language)
 - `POST /game/sense-sprint/rounds/{roundId}/clues/next` - Reveal the next clue for the active round
 - `POST /game/sense-sprint/rounds/{roundId}/guess` - Submit a guess for the round
 
@@ -241,54 +260,35 @@ For React frontend development, CORS is enabled for:
 - `http://localhost:3000`
 - `http://localhost:5173`
 
-## Sense Sprint Frontend (Vite + React)
+## Sense Sprint Demo Game
 
-A dedicated React frontend is available at `source/Demo/sense-sprint-web`.
+A dedicated React + Vite frontend for a word guessing game is available at `source/Demo/sense-sprint-web`.
 
-1. Start the backend host:
+1. Start the backend API (see Testing with Swagger UI above)
+
+2. In another terminal, navigate to the frontend:
 
    ```bash
-   dotnet run --project source/Demo/Lexicala.NET.Demo.Api/Lexicala.NET.Demo.Api.csproj
+   cd source/Demo/sense-sprint-web
    ```
 
-2. In another terminal, navigate to the frontend and install dependencies (required once):
-
-    **PowerShell:**
-
-    ```powershell
-    cd source/Demo/sense-sprint-web
-    npm.cmd install
-    ```
-
-    **Bash / Command Prompt:**
-
-    ```bash
-    cd source/Demo/sense-sprint-web
-    npm install
-    ```
-
-3. Start the frontend dev server:
+3. Install dependencies and start the dev server:
 
    **PowerShell:**
-
    ```powershell
-   cd source/Demo/sense-sprint-web
+   npm.cmd install
    npm.cmd run dev
    ```
 
    **Bash / Command Prompt:**
-
    ```bash
-   cd source/Demo/sense-sprint-web
+   npm install
    npm run dev
    ```
 
-4. Open the app at:
-   - `http://localhost:5173`
+4. Open the app at `http://localhost:5173`
 
-The Vite dev server proxies `/game/*` calls to `http://localhost:5000`, so the game endpoints work without extra CORS setup.
-
-**Note:** PowerShell requires `npm.cmd` due to execution policies. If you see "npm is not recognized", ensure you're using `npm.cmd run dev` (PowerShell) or open Command Prompt / Git Bash instead.
+For complete game documentation, features, and tips, see the [Sense Sprint README](https://github.com/HannoZ/Lexicala.NET/blob/main/source/Demo/sense-sprint-web/README.md).
 
 ## Building from Source
 

--- a/source/Demo/Lexicala.NET.Demo.Api/Game/GameServiceHelpers.cs
+++ b/source/Demo/Lexicala.NET.Demo.Api/Game/GameServiceHelpers.cs
@@ -1,0 +1,22 @@
+using Lexicala.NET.Response;
+
+namespace Lexicala.NET.Demo.Api.Game;
+
+internal static class GameServiceHelpers
+{
+    internal static RateLimitDebugResponse? BuildRateLimit(ResponseMetadata? metadata)
+    {
+        var limits = metadata?.RateLimits;
+        if (limits is null)
+        {
+            return null;
+        }
+
+        if (limits.Limit < 0 || limits.LimitRemaining < 0 || limits.Reset < 0)
+        {
+            return null;
+        }
+
+        return new RateLimitDebugResponse(limits.Limit, limits.LimitRemaining, limits.Reset);
+    }
+}

--- a/source/Demo/Lexicala.NET.Demo.Api/Game/ISenseSprintGameService.cs
+++ b/source/Demo/Lexicala.NET.Demo.Api/Game/ISenseSprintGameService.cs
@@ -6,7 +6,7 @@ namespace Lexicala.NET.Demo.Api.Game;
 
 public interface ISenseSprintGameService
 {
-    Task<CreateRoundResponse> CreateRoundAsync(CancellationToken cancellationToken = default);
+    Task<CreateRoundResponse> CreateRoundAsync(string? language = null, CancellationToken cancellationToken = default);
 
     Task<NextClueResponse> RevealNextClueAsync(Guid roundId, CancellationToken cancellationToken = default);
 

--- a/source/Demo/Lexicala.NET.Demo.Api/Game/ITranslationQuizGameService.cs
+++ b/source/Demo/Lexicala.NET.Demo.Api/Game/ITranslationQuizGameService.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Lexicala.NET.Demo.Api.Game;
+
+public interface ITranslationQuizGameService
+{
+    Task<CreateQuizRoundResponse> CreateRoundAsync(string? targetLanguage = null, CancellationToken cancellationToken = default);
+
+    Task<QuizAnswerResponse> SubmitAnswerAsync(Guid roundId, string choice, CancellationToken cancellationToken = default);
+
+    Task<QuizAnswerResponse> ExpireRoundAsync(Guid roundId, CancellationToken cancellationToken = default);
+}

--- a/source/Demo/Lexicala.NET.Demo.Api/Game/SenseSprintContracts.cs
+++ b/source/Demo/Lexicala.NET.Demo.Api/Game/SenseSprintContracts.cs
@@ -4,6 +4,7 @@ namespace Lexicala.NET.Demo.Api.Game;
 
 public sealed record CreateRoundResponse(
     Guid RoundId,
+    string Language,
     DateTimeOffset ExpiresAtUtc,
     int ClueIndex,
     string Clue,
@@ -12,6 +13,8 @@ public sealed record CreateRoundResponse(
     int RoundSeconds,
     RateLimitDebugResponse? RateLimit
 );
+
+public sealed record CreateRoundRequest(string? Language);
 
 public sealed record RateLimitDebugResponse(
     int Limit,

--- a/source/Demo/Lexicala.NET.Demo.Api/Game/SenseSprintGameService.cs
+++ b/source/Demo/Lexicala.NET.Demo.Api/Game/SenseSprintGameService.cs
@@ -157,19 +157,31 @@ public sealed class SenseSprintGameService : ISenseSprintGameService
     public Task<GuessResponse> GiveUpAsync(Guid roundId, CancellationToken cancellationToken = default)
     {
         var round = GetRequiredRound(roundId);
-        EnsureRoundIsActive(roundId, round);
+
+        if (round.IsCompleted)
+        {
+            return Task.FromResult(new GuessResponse(
+                roundId,
+                false,
+                "completed",
+                0,
+                round.CurrentClueIndex,
+                round.Answer,
+                "Round already completed. Start a new round."));
+        }
 
         round.IsCompleted = true;
         _cache.Set(roundId, round, round.ExpiresAtUtc);
 
+        var isExpired = DateTimeOffset.UtcNow > round.ExpiresAtUtc;
         return Task.FromResult(new GuessResponse(
             roundId,
             false,
-            "lost",
+            isExpired ? "expired" : "lost",
             0,
             round.CurrentClueIndex,
             round.Answer,
-            "Round ended. Better luck next time."));
+            isExpired ? "Time's up! The answer was revealed." : "Round ended. Better luck next time."));
     }
 
     private async Task<SenseSprintRoundState?> TryGenerateRoundAsync(CancellationToken cancellationToken)
@@ -208,24 +220,8 @@ public sealed class SenseSprintGameService : ISenseSprintGameService
             CurrentClueIndex = 0,
             IsCompleted = false,
             ExpiresAtUtc = DateTimeOffset.UtcNow.AddSeconds(RoundSeconds),
-            RateLimit = BuildRateLimit(entry.Metadata) ?? BuildRateLimit(fluky.Metadata)
+            RateLimit = GameServiceHelpers.BuildRateLimit(entry.Metadata) ?? GameServiceHelpers.BuildRateLimit(fluky.Metadata)
         };
-    }
-
-    private static RateLimitDebugResponse? BuildRateLimit(ResponseMetadata? metadata)
-    {
-        var limits = metadata?.RateLimits;
-        if (limits is null)
-        {
-            return null;
-        }
-
-        if (limits.Limit < 0 || limits.LimitRemaining < 0 || limits.Reset < 0)
-        {
-            return null;
-        }
-
-        return new RateLimitDebugResponse(limits.Limit, limits.LimitRemaining, limits.Reset);
     }
 
     private static List<string> BuildClues(Entry entry, Sense sense, string answer)

--- a/source/Demo/Lexicala.NET.Demo.Api/Game/SenseSprintGameService.cs
+++ b/source/Demo/Lexicala.NET.Demo.Api/Game/SenseSprintGameService.cs
@@ -17,6 +17,7 @@ public sealed class SenseSprintGameService : ISenseSprintGameService
     private static readonly int[] ScoresByClueIndex = [4, 3, 2, 1];
     private const int MaxGenerationAttempts = 8;
     private const int RoundSeconds = 60;
+    private const string DefaultLanguage = "en";
 
     private readonly ILexicalaClient _lexicalaClient;
     private readonly IMemoryCache _cache;
@@ -32,11 +33,13 @@ public sealed class SenseSprintGameService : ISenseSprintGameService
         _logger = logger;
     }
 
-    public async Task<CreateRoundResponse> CreateRoundAsync(CancellationToken cancellationToken = default)
+    public async Task<CreateRoundResponse> CreateRoundAsync(string? language = null, CancellationToken cancellationToken = default)
     {
+        var normalizedLanguage = NormalizeLanguage(language);
+
         for (var attempt = 1; attempt <= MaxGenerationAttempts; attempt++)
         {
-            var generated = await TryGenerateRoundAsync(cancellationToken);
+            var generated = await TryGenerateRoundAsync(normalizedLanguage, cancellationToken);
             if (generated is null)
             {
                 _logger.LogDebug("Sense Sprint generation attempt {Attempt} failed quality filters", attempt);
@@ -48,6 +51,7 @@ public sealed class SenseSprintGameService : ISenseSprintGameService
 
             return new CreateRoundResponse(
                 roundId,
+                generated.Language,
                 generated.ExpiresAtUtc,
                 generated.CurrentClueIndex,
                 generated.Clues[generated.CurrentClueIndex],
@@ -184,9 +188,9 @@ public sealed class SenseSprintGameService : ISenseSprintGameService
             isExpired ? "Time's up! The answer was revealed." : "Round ended. Better luck next time."));
     }
 
-    private async Task<SenseSprintRoundState?> TryGenerateRoundAsync(CancellationToken cancellationToken)
+    private async Task<SenseSprintRoundState?> TryGenerateRoundAsync(string language, CancellationToken cancellationToken)
     {
-        var fluky = await _lexicalaClient.FlukySearchAsync(Sources.Global, "en", cancellationToken: cancellationToken);
+        var fluky = await _lexicalaClient.FlukySearchAsync(Sources.Global, language, cancellationToken: cancellationToken);
         var candidate = fluky.Results.FirstOrDefault();
         if (candidate?.Id is null)
         {
@@ -216,12 +220,19 @@ public sealed class SenseSprintGameService : ISenseSprintGameService
         return new SenseSprintRoundState
         {
             Answer = answer,
+            Language = language,
             Clues = clues,
             CurrentClueIndex = 0,
             IsCompleted = false,
             ExpiresAtUtc = DateTimeOffset.UtcNow.AddSeconds(RoundSeconds),
             RateLimit = GameServiceHelpers.BuildRateLimit(entry.Metadata) ?? GameServiceHelpers.BuildRateLimit(fluky.Metadata)
         };
+    }
+
+    private static string NormalizeLanguage(string? language)
+    {
+        var normalized = language?.Trim().ToLowerInvariant();
+        return string.IsNullOrWhiteSpace(normalized) ? DefaultLanguage : normalized;
     }
 
     private static List<string> BuildClues(Entry entry, Sense sense, string answer)
@@ -332,6 +343,8 @@ public sealed class SenseSprintGameService : ISenseSprintGameService
     private sealed class SenseSprintRoundState
     {
         public required string Answer { get; init; }
+
+        public required string Language { get; init; }
 
         public required List<string> Clues { get; init; }
 

--- a/source/Demo/Lexicala.NET.Demo.Api/Game/TranslationQuizContracts.cs
+++ b/source/Demo/Lexicala.NET.Demo.Api/Game/TranslationQuizContracts.cs
@@ -1,0 +1,25 @@
+using System;
+
+namespace Lexicala.NET.Demo.Api.Game;
+
+public sealed record CreateQuizRoundResponse(
+    Guid RoundId,
+    string SourceWord,
+    string SourceLanguage,
+    string TargetLanguage,
+    string[] Choices,
+    DateTimeOffset ExpiresAtUtc,
+    int RoundSeconds,
+    RateLimitDebugResponse? RateLimit
+);
+
+public sealed record QuizAnswerRequest(string Choice);
+
+public sealed record QuizAnswerResponse(
+    Guid RoundId,
+    bool IsCorrect,
+    string RoundStatus,
+    int AwardedPoints,
+    string CorrectAnswer,
+    string? Message
+);

--- a/source/Demo/Lexicala.NET.Demo.Api/Game/TranslationQuizGameService.cs
+++ b/source/Demo/Lexicala.NET.Demo.Api/Game/TranslationQuizGameService.cs
@@ -14,14 +14,17 @@ namespace Lexicala.NET.Demo.Api.Game;
 public sealed class TranslationQuizGameService : ITranslationQuizGameService
 {
     private const string LanguagesCacheKey = "translation-quiz-languages";
+    private const string DistractorPoolCacheKeyPrefix = "translation-quiz-distractors:";
     private const int MaxGenerationAttempts = 8;
     private const int QuizRoundSeconds = 30;
     private const int ChoiceCount = 4;
+    private const int MaxDistractorPoolSize = 24;
     // Keeps rounds accessible for a short window after the game timer elapses so
     // that /expire and late /answer calls succeed even when the client sends the
     // request a few seconds after the server-side deadline.
     private static readonly TimeSpan RoundCacheGracePeriod = TimeSpan.FromMinutes(5);
     private static readonly TimeSpan ExpireEarlyTolerance = TimeSpan.FromSeconds(3);
+    private static readonly TimeSpan DistractorPoolCacheDuration = TimeSpan.FromMinutes(30);
 
     private readonly ILexicalaClient _lexicalaClient;
     private readonly IMemoryCache _cache;
@@ -234,20 +237,7 @@ public sealed class TranslationQuizGameService : ITranslationQuizGameService
             return null;
         }
 
-        // Fetch distractors in parallel: FlukySearch in the target language, use headwords as wrong choices
-        var distractorTasks = Enumerable.Range(0, ChoiceCount - 1)
-            .Select(_ => _lexicalaClient.FlukySearchAsync(Sources.Global, targetLanguage, cancellationToken: cancellationToken))
-            .ToArray();
-
-        var distractorResults = await Task.WhenAll(distractorTasks);
-
-        var distractors = distractorResults
-            .Select(r => GetFirstHeadword(r.Results.FirstOrDefault()))
-            .OfType<string>()
-            .Where(d => !string.IsNullOrWhiteSpace(d) && !string.Equals(d, correctTranslation, StringComparison.OrdinalIgnoreCase))
-            .Distinct(StringComparer.OrdinalIgnoreCase)
-            .Take(ChoiceCount - 1)
-            .ToList();
+        var distractors = await GetDistractorsAsync(targetLanguage, correctTranslation, cancellationToken);
 
         if (distractors.Count < ChoiceCount - 1)
         {
@@ -270,6 +260,82 @@ public sealed class TranslationQuizGameService : ITranslationQuizGameService
             RateLimit = GameServiceHelpers.BuildRateLimit(entry.Metadata) ?? GameServiceHelpers.BuildRateLimit(fluky.Metadata)
         };
     }
+
+    private async Task<List<string>> GetDistractorsAsync(string targetLanguage, string correctTranslation, CancellationToken cancellationToken)
+    {
+        var poolKey = GetDistractorPoolCacheKey(targetLanguage);
+        var pool = _cache.TryGetValue(poolKey, out string[]? cachedPool) && cachedPool is not null
+            ? cachedPool
+                .Where(candidate => !string.IsNullOrWhiteSpace(candidate))
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Take(MaxDistractorPoolSize)
+                .ToList()
+            : [];
+
+        var distractors = PickDistractors(pool, correctTranslation);
+        if (distractors.Count == ChoiceCount - 1)
+        {
+            return distractors;
+        }
+
+        var missingCount = ChoiceCount - 1 - distractors.Count;
+        var fetchedDistractors = await FetchDistractorCandidatesAsync(targetLanguage, missingCount, cancellationToken);
+        if (fetchedDistractors.Count > 0)
+        {
+            foreach (var candidate in fetchedDistractors)
+            {
+                if (pool.Contains(candidate, StringComparer.OrdinalIgnoreCase))
+                {
+                    continue;
+                }
+
+                pool.Add(candidate);
+            }
+
+            var persistedPool = pool
+                .Distinct(StringComparer.OrdinalIgnoreCase)
+                .Take(MaxDistractorPoolSize)
+                .ToArray();
+
+            _cache.Set(poolKey, persistedPool, DistractorPoolCacheDuration);
+            distractors = PickDistractors(persistedPool, correctTranslation);
+        }
+
+        return distractors;
+    }
+
+    private async Task<List<string>> FetchDistractorCandidatesAsync(string targetLanguage, int count, CancellationToken cancellationToken)
+    {
+        if (count <= 0)
+        {
+            return [];
+        }
+
+        var distractorTasks = Enumerable.Range(0, count)
+            .Select(_ => _lexicalaClient.FlukySearchAsync(Sources.Global, targetLanguage, cancellationToken: cancellationToken))
+            .ToArray();
+
+        var distractorResults = await Task.WhenAll(distractorTasks);
+
+        return distractorResults
+            .Select(r => GetFirstHeadword(r.Results.FirstOrDefault()))
+            .OfType<string>()
+            .Where(candidate => !string.IsNullOrWhiteSpace(candidate))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .ToList();
+    }
+
+    private static List<string> PickDistractors(IEnumerable<string> pool, string correctTranslation)
+    {
+        return pool
+            .Where(candidate => !string.Equals(candidate, correctTranslation, StringComparison.OrdinalIgnoreCase))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .OrderBy(_ => Random.Shared.Next())
+            .Take(ChoiceCount - 1)
+            .ToList();
+    }
+
+    private static string GetDistractorPoolCacheKey(string targetLanguage) => $"{DistractorPoolCacheKeyPrefix}{targetLanguage}";
 
     private static string? FindTranslation(Lexicala.NET.Response.Entries.Entry entry, string targetLanguage)
     {

--- a/source/Demo/Lexicala.NET.Demo.Api/Game/TranslationQuizGameService.cs
+++ b/source/Demo/Lexicala.NET.Demo.Api/Game/TranslationQuizGameService.cs
@@ -1,0 +1,330 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Lexicala.NET.Request;
+using Lexicala.NET.Response.Entries;
+using Lexicala.NET.Response.Search;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+
+namespace Lexicala.NET.Demo.Api.Game;
+
+public sealed class TranslationQuizGameService : ITranslationQuizGameService
+{
+    private const string LanguagesCacheKey = "translation-quiz-languages";
+    private const int MaxGenerationAttempts = 8;
+    private const int QuizRoundSeconds = 30;
+    private const int ChoiceCount = 4;
+    // Keeps rounds accessible for a short window after the game timer elapses so
+    // that /expire and late /answer calls succeed even when the client sends the
+    // request a few seconds after the server-side deadline.
+    private static readonly TimeSpan RoundCacheGracePeriod = TimeSpan.FromMinutes(5);
+    private static readonly TimeSpan ExpireEarlyTolerance = TimeSpan.FromSeconds(3);
+
+    private readonly ILexicalaClient _lexicalaClient;
+    private readonly IMemoryCache _cache;
+    private readonly ILogger<TranslationQuizGameService> _logger;
+
+    public TranslationQuizGameService(
+        ILexicalaClient lexicalaClient,
+        IMemoryCache cache,
+        ILogger<TranslationQuizGameService> logger)
+    {
+        _lexicalaClient = lexicalaClient;
+        _cache = cache;
+        _logger = logger;
+    }
+
+    public async Task<CreateQuizRoundResponse> CreateRoundAsync(string? targetLanguage = null, CancellationToken cancellationToken = default)
+    {
+        var availableLanguages = await GetTargetLanguagesAsync(cancellationToken);
+
+        string resolvedLanguage;
+        if (string.IsNullOrWhiteSpace(targetLanguage))
+        {
+            if (availableLanguages.Length == 0)
+            {
+                throw new InvalidOperationException("No target languages are available. Try again later.");
+            }
+
+            resolvedLanguage = availableLanguages[Random.Shared.Next(availableLanguages.Length)];
+        }
+        else
+        {
+            resolvedLanguage = targetLanguage.Trim().ToLowerInvariant();
+        }
+
+        for (var attempt = 1; attempt <= MaxGenerationAttempts; attempt++)
+        {
+            var generated = await TryGenerateRoundAsync(resolvedLanguage, cancellationToken);
+            if (generated is null)
+            {
+                _logger.LogDebug("Translation Quiz generation attempt {Attempt} failed quality filters", attempt);
+                continue;
+            }
+
+            var roundId = Guid.NewGuid();
+            _cache.Set(roundId, generated, generated.ExpiresAtUtc + RoundCacheGracePeriod);
+
+            return new CreateQuizRoundResponse(
+                roundId,
+                generated.SourceWord,
+                "en",
+                resolvedLanguage,
+                generated.Choices,
+                generated.ExpiresAtUtc,
+                QuizRoundSeconds,
+                generated.RateLimit);
+        }
+
+        throw new InvalidOperationException("Could not generate a playable round. Try again.");
+    }
+
+    public Task<QuizAnswerResponse> SubmitAnswerAsync(Guid roundId, string choice, CancellationToken cancellationToken = default)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(choice);
+
+        var round = GetRequiredRound(roundId);
+
+        if (round.IsCompleted)
+        {
+            return Task.FromResult(new QuizAnswerResponse(
+                roundId,
+                false,
+                "completed",
+                0,
+                round.CorrectAnswer,
+                "Round already completed. Start a new round."));
+        }
+
+        round.IsCompleted = true;
+        _cache.Set(roundId, round, round.ExpiresAtUtc + RoundCacheGracePeriod);
+
+        var isExpired = DateTimeOffset.UtcNow > round.ExpiresAtUtc;
+        if (isExpired)
+        {
+            return Task.FromResult(new QuizAnswerResponse(
+                roundId,
+                false,
+                "expired",
+                0,
+                round.CorrectAnswer,
+                "Time's up! Start a new round."));
+        }
+
+        var isCorrect = string.Equals(round.CorrectAnswer, choice.Trim(), StringComparison.OrdinalIgnoreCase);
+        if (isCorrect)
+        {
+            return Task.FromResult(new QuizAnswerResponse(
+                roundId,
+                true,
+                "won",
+                1,
+                round.CorrectAnswer,
+                "Correct!"));
+        }
+
+        return Task.FromResult(new QuizAnswerResponse(
+            roundId,
+            false,
+            "lost",
+            0,
+            round.CorrectAnswer,
+            $"Incorrect. The correct translation was: {round.CorrectAnswer}"));
+    }
+
+    public Task<QuizAnswerResponse> ExpireRoundAsync(Guid roundId, CancellationToken cancellationToken = default)
+    {
+        var round = GetRequiredRound(roundId);
+
+        if (round.IsCompleted)
+        {
+            return Task.FromResult(new QuizAnswerResponse(
+                roundId,
+                false,
+                "completed",
+                0,
+                round.CorrectAnswer,
+                "Round already completed. Start a new round."));
+        }
+
+        round.IsCompleted = true;
+        _cache.Set(roundId, round, round.ExpiresAtUtc + RoundCacheGracePeriod);
+
+        // Allow a small tolerance for client-side timer rounding; reject if called well before expiry
+        var isNearOrPastExpiry = DateTimeOffset.UtcNow >= round.ExpiresAtUtc - ExpireEarlyTolerance;
+        if (!isNearOrPastExpiry)
+        {
+            return Task.FromResult(new QuizAnswerResponse(
+                roundId,
+                false,
+                "lost",
+                0,
+                round.CorrectAnswer,
+                "Round expiry requested before the timer has elapsed."));
+        }
+
+        return Task.FromResult(new QuizAnswerResponse(
+            roundId,
+            false,
+            "expired",
+            0,
+            round.CorrectAnswer,
+            "Time's up!"));
+    }
+
+    public async Task<string[]> GetTargetLanguagesAsync(CancellationToken cancellationToken)
+    {
+        if (_cache.TryGetValue(LanguagesCacheKey, out string[]? cached) && cached is not null)
+        {
+            return cached;
+        }
+
+        try
+        {
+            var languages = await _lexicalaClient.LanguagesAsync(cancellationToken);
+
+            // Prefer explicit target_languages; fall back to source_languages excluding "en"
+            var targetLanguages = (languages.Resources?.Global?.TargetLanguages is { Length: > 0 } tl ? tl
+                : languages.Resources?.Global?.SourceLanguages ?? [])
+                .Select(l => l.Trim().ToLowerInvariant())
+                .Where(l => l.Length > 0 && l != "en")
+                .Distinct()
+                .OrderBy(l => l)
+                .ToArray();
+
+            if (targetLanguages.Length > 0)
+            {
+                _cache.Set(LanguagesCacheKey, targetLanguages, TimeSpan.FromHours(1));
+            }
+
+            return targetLanguages;
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to fetch languages from API; using fallback list");
+            return ["de", "nl", "fr", "es"];
+        }
+    }
+
+    private async Task<TranslationQuizRoundState?> TryGenerateRoundAsync(string targetLanguage, CancellationToken cancellationToken)
+    {
+        // Get a random English word via FlukySearch
+        var fluky = await _lexicalaClient.FlukySearchAsync(Sources.Global, "en", cancellationToken: cancellationToken);
+        var candidate = fluky.Results.FirstOrDefault();
+        if (candidate?.Id is null)
+        {
+            return null;
+        }
+
+        // Fetch the full entry to access its translations
+        var entry = await _lexicalaClient.GetEntryAsync(candidate.Id, cancellationToken: cancellationToken);
+        var sourceWord = entry.Headwords.FirstOrDefault()?.Text;
+        if (string.IsNullOrWhiteSpace(sourceWord))
+        {
+            return null;
+        }
+
+        // Find a translation in the target language from any sense
+        var correctTranslation = FindTranslation(entry, targetLanguage);
+        if (string.IsNullOrWhiteSpace(correctTranslation))
+        {
+            return null;
+        }
+
+        // Fetch distractors in parallel: FlukySearch in the target language, use headwords as wrong choices
+        var distractorTasks = Enumerable.Range(0, ChoiceCount - 1)
+            .Select(_ => _lexicalaClient.FlukySearchAsync(Sources.Global, targetLanguage, cancellationToken: cancellationToken))
+            .ToArray();
+
+        var distractorResults = await Task.WhenAll(distractorTasks);
+
+        var distractors = distractorResults
+            .Select(r => GetFirstHeadword(r.Results.FirstOrDefault()))
+            .OfType<string>()
+            .Where(d => !string.IsNullOrWhiteSpace(d) && !string.Equals(d, correctTranslation, StringComparison.OrdinalIgnoreCase))
+            .Distinct(StringComparer.OrdinalIgnoreCase)
+            .Take(ChoiceCount - 1)
+            .ToList();
+
+        if (distractors.Count < ChoiceCount - 1)
+        {
+            return null;
+        }
+
+        // Build shuffled choices (1 correct + 3 distractors)
+        var choices = distractors
+            .Append(correctTranslation)
+            .OrderBy(_ => Random.Shared.Next())
+            .ToArray();
+
+        return new TranslationQuizRoundState
+        {
+            SourceWord = sourceWord,
+            CorrectAnswer = correctTranslation,
+            Choices = choices,
+            ExpiresAtUtc = DateTimeOffset.UtcNow.AddSeconds(QuizRoundSeconds),
+            IsCompleted = false,
+            RateLimit = GameServiceHelpers.BuildRateLimit(entry.Metadata) ?? GameServiceHelpers.BuildRateLimit(fluky.Metadata)
+        };
+    }
+
+    private static string? FindTranslation(Lexicala.NET.Response.Entries.Entry entry, string targetLanguage)
+    {
+        foreach (var sense in entry.Senses)
+        {
+            if (sense.Translations.TryGetValue(targetLanguage, out var translationObj))
+            {
+                var text = translationObj.Translation?.Text
+                    ?? translationObj.Translations?.FirstOrDefault()?.Text;
+
+                if (!string.IsNullOrWhiteSpace(text))
+                {
+                    return text;
+                }
+            }
+        }
+
+        return null;
+    }
+
+    private static string? GetFirstHeadword(Lexicala.NET.Response.Search.Result? result)
+    {
+        if (result is null)
+        {
+            return null;
+        }
+
+        var hw = result.Headword;
+        return hw.HeadwordElementArray is { Length: > 0 }
+            ? hw.HeadwordElementArray[0].Text
+            : hw.Headword?.Text;
+    }
+
+    private TranslationQuizRoundState GetRequiredRound(Guid roundId)
+    {
+        if (!_cache.TryGetValue(roundId, out TranslationQuizRoundState? round) || round is null)
+        {
+            throw new KeyNotFoundException("Round not found. Start a new round.");
+        }
+
+        return round;
+    }
+
+    private sealed class TranslationQuizRoundState
+    {
+        public required string SourceWord { get; init; }
+
+        public required string CorrectAnswer { get; init; }
+
+        public required string[] Choices { get; init; }
+
+        public required DateTimeOffset ExpiresAtUtc { get; init; }
+
+        public bool IsCompleted { get; set; }
+
+        public RateLimitDebugResponse? RateLimit { get; init; }
+    }
+}

--- a/source/Demo/Lexicala.NET.Demo.Api/Game/TranslationQuizGameService.cs
+++ b/source/Demo/Lexicala.NET.Demo.Api/Game/TranslationQuizGameService.cs
@@ -153,9 +153,6 @@ public sealed class TranslationQuizGameService : ITranslationQuizGameService
                 "Round already completed. Start a new round."));
         }
 
-        round.IsCompleted = true;
-        _cache.Set(roundId, round, round.ExpiresAtUtc + RoundCacheGracePeriod);
-
         // Allow a small tolerance for client-side timer rounding; reject if called well before expiry
         var isNearOrPastExpiry = DateTimeOffset.UtcNow >= round.ExpiresAtUtc - ExpireEarlyTolerance;
         if (!isNearOrPastExpiry)
@@ -168,6 +165,9 @@ public sealed class TranslationQuizGameService : ITranslationQuizGameService
                 round.CorrectAnswer,
                 "Round expiry requested before the timer has elapsed."));
         }
+
+        round.IsCompleted = true;
+        _cache.Set(roundId, round, round.ExpiresAtUtc + RoundCacheGracePeriod);
 
         return Task.FromResult(new QuizAnswerResponse(
             roundId,

--- a/source/Demo/Lexicala.NET.Demo.Api/Lexicala.NET.Demo.Api.csproj
+++ b/source/Demo/Lexicala.NET.Demo.Api/Lexicala.NET.Demo.Api.csproj
@@ -5,6 +5,8 @@
     <TargetFramework>net10.0</TargetFramework>
     <Nullable>enable</Nullable>
     <UserSecretsId>83e2368c-8e8a-4e8e-9f3d-c00d575b6393</UserSecretsId>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>CS1591</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/source/Demo/Lexicala.NET.Demo.Api/Program.cs
+++ b/source/Demo/Lexicala.NET.Demo.Api/Program.cs
@@ -29,6 +29,7 @@ namespace Lexicala.NET.Demo.Api
 
             builder.Services.RegisterLexicala(builder.Configuration);
             builder.Services.AddSingleton<ISenseSprintGameService, SenseSprintGameService>();
+            builder.Services.AddSingleton<ITranslationQuizGameService, TranslationQuizGameService>();
             builder.Services.AddEndpointsApiExplorer();
             builder.Services.AddCors(options =>
             {
@@ -173,6 +174,52 @@ namespace Lexicala.NET.Demo.Api
                     }
                 })
                 .WithName("SenseSprintGiveUp");
+
+            app.MapPost("/game/translation-quiz/rounds", async (ITranslationQuizGameService gameService, string? targetLanguage, CancellationToken cancellationToken) =>
+                {
+                    try
+                    {
+                        var response = await gameService.CreateRoundAsync(targetLanguage, cancellationToken);
+                        return Results.Ok(response);
+                    }
+                    catch (InvalidOperationException ex)
+                    {
+                        return Results.Problem(ex.Message, statusCode: StatusCodes.Status503ServiceUnavailable);
+                    }
+                })
+                .WithName("TranslationQuizCreateRound");
+
+            app.MapPost("/game/translation-quiz/rounds/{roundId:guid}/answer", async (ITranslationQuizGameService gameService, Guid roundId, QuizAnswerRequest request, CancellationToken cancellationToken) =>
+                {
+                    try
+                    {
+                        var response = await gameService.SubmitAnswerAsync(roundId, request.Choice, cancellationToken);
+                        return Results.Ok(response);
+                    }
+                    catch (KeyNotFoundException ex)
+                    {
+                        return Results.NotFound(new ProblemDetails { Title = "Round not found", Detail = ex.Message });
+                    }
+                    catch (ArgumentException ex)
+                    {
+                        return Results.BadRequest(new ProblemDetails { Title = "Invalid answer", Detail = ex.Message });
+                    }
+                })
+                .WithName("TranslationQuizSubmitAnswer");
+
+            app.MapPost("/game/translation-quiz/rounds/{roundId:guid}/expire", async (ITranslationQuizGameService gameService, Guid roundId, CancellationToken cancellationToken) =>
+                {
+                    try
+                    {
+                        var response = await gameService.ExpireRoundAsync(roundId, cancellationToken);
+                        return Results.Ok(response);
+                    }
+                    catch (KeyNotFoundException ex)
+                    {
+                        return Results.NotFound(new ProblemDetails { Title = "Round not found", Detail = ex.Message });
+                    }
+                })
+                .WithName("TranslationQuizExpireRound");
 
             await app.RunAsync();
         }

--- a/source/Demo/Lexicala.NET.Demo.Api/Program.cs
+++ b/source/Demo/Lexicala.NET.Demo.Api/Program.cs
@@ -107,11 +107,11 @@ namespace Lexicala.NET.Demo.Api
                 await client.FlukySearchAsync(source ?? "global", language, etag, cancellationToken))
                 .WithName("FlukySearch");
 
-            app.MapPost("/game/sense-sprint/rounds", async (ISenseSprintGameService gameService, CancellationToken cancellationToken) =>
+            app.MapPost("/game/sense-sprint/rounds", async (ISenseSprintGameService gameService, CreateRoundRequest? request, CancellationToken cancellationToken) =>
                 {
                     try
                     {
-                        var response = await gameService.CreateRoundAsync(cancellationToken);
+                        var response = await gameService.CreateRoundAsync(request?.Language, cancellationToken);
                         return Results.Ok(response);
                     }
                     catch (InvalidOperationException ex)

--- a/source/Demo/Lexicala.NET.Demo.Api/Program.cs
+++ b/source/Demo/Lexicala.NET.Demo.Api/Program.cs
@@ -43,7 +43,19 @@ namespace Lexicala.NET.Demo.Api
             });
             builder.Services.AddSwaggerGen(options =>
             {
+                options.SwaggerDoc("v1", new Microsoft.OpenApi.Models.OpenApiInfo
+                {
+                    Title = "Lexicala API",
+                    Version = "v1",
+                    Description = "Explore the Lexicala dictionary API \u2014 search headwords, retrieve entries and senses, browse definitions, and discover random words across 25+ languages. See the <a href=\"https://api.lexicala.com/documentation/\">official Lexicala API documentation</a> for full details."
+                });
                 options.CustomSchemaIds(type => type.FullName);
+                foreach (var xmlFile in new[] { "Lexicala.NET.Demo.Api.xml", "Lexicala.NET.xml" })
+                {
+                    var xmlPath = System.IO.Path.Combine(AppContext.BaseDirectory, xmlFile);
+                    if (System.IO.File.Exists(xmlPath))
+                        options.IncludeXmlComments(xmlPath);
+                }
             });
             builder.Services.AddLogging(cfg => cfg.AddConsole());
 
@@ -51,61 +63,99 @@ namespace Lexicala.NET.Demo.Api
 
             app.UseCors("ReactDev");
             app.UseDefaultFiles();
-            app.UseStaticFiles();
             app.UseSwagger();
             app.UseSwaggerUI();
 
             app.MapGet("/test", async (ILexicalaClient client, CancellationToken cancellationToken) =>
                 await client.TestAsync(cancellationToken))
-                .WithName("Test");
+                .WithName("Test")
+                .WithTags("Health")
+                .WithSummary("Health check")
+                .WithDescription("Tests that the API is reachable and returns a status message.");
 
             app.MapGet("/languages", async (ILexicalaClient client, CancellationToken cancellationToken) =>
                 await client.LanguagesAsync(cancellationToken))
-                .WithName("Languages");
+                .WithName("Languages")
+                .WithTags("Languages")
+                .WithSummary("List available languages")
+                .WithDescription("Returns information about all languages and resources available through the API, including the Global, Password, and Random House Webster's series.");
 
             app.MapGet("/search", async (ILexicalaClient client, string text, string language, string? etag, CancellationToken cancellationToken) =>
                 await client.BasicSearchAsync(text, language, etag, cancellationToken))
-                .WithName("BasicSearch");
+                .WithName("BasicSearch")
+                .WithTags("Search")
+                .WithSummary("Search by headword")
+                .WithDescription("Search for entries in the Global source by headword. Returns partial lexical information. Use /entry/{entryId} to retrieve a full entry.");
 
             app.MapGet("/search-entries", async (ILexicalaClient client, string text, string language, string? etag, CancellationToken cancellationToken) =>
                 await client.SearchEntriesAsync(text, language, etag, cancellationToken))
-                .WithName("SearchEntries");
+                .WithName("SearchEntries")
+                .WithTags("Search")
+                .WithSummary("Search by headword — full entries")
+                .WithDescription("Search for entries in the Global source by headword and return complete entry objects, including all syntactic and semantic details.");
 
             app.MapGet("/search-rdf", async (ILexicalaClient client, string text, string language, string? etag, CancellationToken cancellationToken) =>
                 Results.Text(await client.SearchRdfAsync(text, language, etag, cancellationToken), "application/ld+json"))
-                .WithName("SearchRdf");
+                .WithName("SearchRdf")
+                .WithTags("Search")
+                .WithSummary("Search entries in RDF/JSON-LD format")
+                .WithDescription("Search for entries by headword and return results serialised as RDF/JSON-LD.");
 
             app.MapGet("/entry/{entryId}", async (ILexicalaClient client, string entryId, string? etag, CancellationToken cancellationToken) =>
                 await client.GetEntryAsync(entryId, etag, cancellationToken))
-                .WithName("GetEntry");
+                .WithName("GetEntry")
+                .WithTags("Entries")
+                .WithSummary("Get entry by ID")
+                .WithDescription("Retrieves a full dictionary entry by its ID, including syntactic and semantic information, compositional phrases, usage examples, and translations.");
 
             app.MapGet("/sense/{senseId}", async (ILexicalaClient client, string senseId, string? etag, CancellationToken cancellationToken) =>
                 await client.GetSenseAsync(senseId, etag, cancellationToken))
-                .WithName("GetSense");
+                .WithName("GetSense")
+                .WithTags("Entries")
+                .WithSummary("Get sense by ID")
+                .WithDescription("Retrieves a single sense by its unique sense ID. Sense IDs are returned as part of search results.");
 
             app.MapGet("/rdf/{entryId}", async (ILexicalaClient client, string entryId, string? etag, CancellationToken cancellationToken) =>
                 Results.Text(await client.GetRdfAsync(entryId, etag, cancellationToken), "application/ld+json"))
-                .WithName("GetRdf");
+                .WithName("GetRdf")
+                .WithTags("Entries")
+                .WithSummary("Get entry in RDF/JSON-LD format")
+                .WithDescription("Retrieves a dictionary entry by ID and returns it serialised as RDF/JSON-LD.");
 
             app.MapPost("/search-advanced", async (ILexicalaClient client, AdvancedSearchRequest request, CancellationToken cancellationToken) =>
                 await client.AdvancedSearchAsync(request, cancellationToken))
-                .WithName("AdvancedSearch");
+                .WithName("AdvancedSearch")
+                .WithTags("Advanced Search")
+                .WithSummary("Advanced search")
+                .WithDescription("Search for entries using flexible filter parameters such as part of speech, gender, number, morphological analysis, synonyms, antonyms, and pagination.");
 
             app.MapPost("/search-entries-advanced", async (ILexicalaClient client, AdvancedSearchRequest request, CancellationToken cancellationToken) =>
                 await client.AdvancedSearchEntriesAsync(request, cancellationToken))
-                .WithName("AdvancedSearchEntries");
+                .WithName("AdvancedSearchEntries")
+                .WithTags("Advanced Search")
+                .WithSummary("Advanced search — full entries")
+                .WithDescription("Search for entries using advanced filter parameters and return complete entry objects.");
 
             app.MapPost("/search-rdf-advanced", async (ILexicalaClient client, AdvancedSearchRequest request, CancellationToken cancellationToken) =>
                 Results.Text(await client.AdvancedSearchRdfAsync(request, cancellationToken), "application/ld+json"))
-                .WithName("AdvancedSearchRdf");
+                .WithName("AdvancedSearchRdf")
+                .WithTags("Advanced Search")
+                .WithSummary("Advanced search in RDF/JSON-LD format")
+                .WithDescription("Search for entries using advanced filter parameters and return results serialised as RDF/JSON-LD.");
 
             app.MapGet("/search-definitions", async (ILexicalaClient client, string text, string? language, string? etag, CancellationToken cancellationToken) =>
                 await client.SearchDefinitionsAsync(text, language, etag, cancellationToken))
-                .WithName("SearchDefinitions");
+                .WithName("SearchDefinitions")
+                .WithTags("Definitions")
+                .WithSummary("Search by definition text")
+                .WithDescription("Performs a full-text search in definitions across 20+ supported languages (ar, cs, da, de, el, en, es, fr, he, hi, it, ja, ko, nl, no, pl, pt, ru, sv, tr). Optionally filter results by language code.");
 
             app.MapGet("/fluky-search", async (ILexicalaClient client, string? source, string? language, string? etag, CancellationToken cancellationToken) =>
                 await client.FlukySearchAsync(source ?? "global", language, etag, cancellationToken))
-                .WithName("FlukySearch");
+                .WithName("FlukySearch")
+                .WithTags("Discovery")
+                .WithSummary("Random word discovery")
+                .WithDescription("Returns a randomly selected entry for word discovery. Filter by source (global, password, multigloss, random) and optionally by language code.");
 
             app.MapPost("/game/sense-sprint/rounds", async (ISenseSprintGameService gameService, CreateRoundRequest? request, CancellationToken cancellationToken) =>
                 {
@@ -119,7 +169,8 @@ namespace Lexicala.NET.Demo.Api
                         return Results.Problem(ex.Message, statusCode: StatusCodes.Status503ServiceUnavailable);
                     }
                 })
-                .WithName("SenseSprintCreateRound");
+                .WithName("SenseSprintCreateRound")
+                .ExcludeFromDescription();
 
             app.MapPost("/game/sense-sprint/rounds/{roundId:guid}/clues/next", async (ISenseSprintGameService gameService, Guid roundId, CancellationToken cancellationToken) =>
                 {
@@ -137,7 +188,8 @@ namespace Lexicala.NET.Demo.Api
                         return Results.BadRequest(new ProblemDetails { Title = "Round is not active", Detail = ex.Message });
                     }
                 })
-                .WithName("SenseSprintNextClue");
+                .WithName("SenseSprintNextClue")
+                .ExcludeFromDescription();
 
             app.MapPost("/game/sense-sprint/rounds/{roundId:guid}/guess", async (ISenseSprintGameService gameService, Guid roundId, GuessRequest request, CancellationToken cancellationToken) =>
                 {
@@ -155,7 +207,8 @@ namespace Lexicala.NET.Demo.Api
                         return Results.BadRequest(new ProblemDetails { Title = "Invalid guess", Detail = ex.Message });
                     }
                 })
-                .WithName("SenseSprintSubmitGuess");
+                .WithName("SenseSprintSubmitGuess")
+                .ExcludeFromDescription();
 
             app.MapPost("/game/sense-sprint/rounds/{roundId:guid}/give-up", async (ISenseSprintGameService gameService, Guid roundId, CancellationToken cancellationToken) =>
                 {
@@ -173,7 +226,8 @@ namespace Lexicala.NET.Demo.Api
                         return Results.BadRequest(new ProblemDetails { Title = "Round is not active", Detail = ex.Message });
                     }
                 })
-                .WithName("SenseSprintGiveUp");
+                .WithName("SenseSprintGiveUp")
+                .ExcludeFromDescription();
 
             app.MapPost("/game/translation-quiz/rounds", async (ITranslationQuizGameService gameService, string? targetLanguage, CancellationToken cancellationToken) =>
                 {
@@ -187,7 +241,8 @@ namespace Lexicala.NET.Demo.Api
                         return Results.Problem(ex.Message, statusCode: StatusCodes.Status503ServiceUnavailable);
                     }
                 })
-                .WithName("TranslationQuizCreateRound");
+                .WithName("TranslationQuizCreateRound")
+                .ExcludeFromDescription();
 
             app.MapPost("/game/translation-quiz/rounds/{roundId:guid}/answer", async (ITranslationQuizGameService gameService, Guid roundId, QuizAnswerRequest request, CancellationToken cancellationToken) =>
                 {
@@ -205,7 +260,8 @@ namespace Lexicala.NET.Demo.Api
                         return Results.BadRequest(new ProblemDetails { Title = "Invalid answer", Detail = ex.Message });
                     }
                 })
-                .WithName("TranslationQuizSubmitAnswer");
+                .WithName("TranslationQuizSubmitAnswer")
+                .ExcludeFromDescription();
 
             app.MapPost("/game/translation-quiz/rounds/{roundId:guid}/expire", async (ITranslationQuizGameService gameService, Guid roundId, CancellationToken cancellationToken) =>
                 {
@@ -219,7 +275,8 @@ namespace Lexicala.NET.Demo.Api
                         return Results.NotFound(new ProblemDetails { Title = "Round not found", Detail = ex.Message });
                     }
                 })
-                .WithName("TranslationQuizExpireRound");
+                .WithName("TranslationQuizExpireRound")
+                .ExcludeFromDescription();
 
             await app.RunAsync();
         }

--- a/source/Demo/sense-sprint-web/.gitignore
+++ b/source/Demo/sense-sprint-web/.gitignore
@@ -22,3 +22,7 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+
+# Playwright
+playwright-report
+test-results

--- a/source/Demo/sense-sprint-web/README.md
+++ b/source/Demo/sense-sprint-web/README.md
@@ -35,7 +35,7 @@ A lexical word guessing game powered by the Lexicala API. The web demo includes 
    dotnet run --project ../Lexicala.NET.Demo.Api/Lexicala.NET.Demo.Api.csproj
    ```
 
-2. **Node.js**: Ensure Node.js is installed (v16+)
+2. **Node.js**: Ensure Node.js is installed (v18+)
 
 ### Development
 

--- a/source/Demo/sense-sprint-web/README.md
+++ b/source/Demo/sense-sprint-web/README.md
@@ -1,73 +1,136 @@
-# React + TypeScript + Vite
+# Sense Sprint
 
-This template provides a minimal setup to get React working in Vite with HMR and some ESLint rules.
+A lexical word guessing game powered by the Lexicala API. Guess the hidden English word from progressively revealed linguistic clues using Fluky Search.
 
-Currently, two official plugins are available:
+## Features
 
-- [@vitejs/plugin-react](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react) uses [Oxc](https://oxc.rs)
-- [@vitejs/plugin-react-swc](https://github.com/vitejs/vite-plugin-react/blob/main/packages/plugin-react-swc) uses [SWC](https://swc.rs/)
+- **Streak Progression**: Build winning streaks with progressive score multipliers
+  - 3 wins: 1.15x scoring bonus
+  - 5 wins: 1.35x bonus + major celebration animation
+  - 10 wins: 1.65x bonus
+  - 15+ wins: 2.00x bonus
+- **Persistent Stats**: All-time statistics saved locally including:
+  - Current and high score
+  - Win/loss record
+  - Expiration and give-up counts
+  - Words guessed correctly
+  - Clues requested and total guesses
+  - Average clues per round
+  - Current and highest streak
+  - Major celebrations unlocked
+- **Session Recovery**: Your active round is saved locally, so page reloads resume mid-game
+- **Streak Warnings**: Confirm before starting a new word if it will reset your streak
+- **Stats Reset**: Clear all saved statistics with one confirmed action (current round preserved)
 
-## React Compiler
+## Getting Started
 
-The React Compiler is not enabled on this template because of its impact on dev & build performances. To add it, see [this documentation](https://react.dev/learn/react-compiler/installation).
+### Prerequisites
 
-## Expanding the ESLint configuration
+1. **Backend API Running**: Start the Lexicala.NET.Demo.Api first (see main README for setup)
+   ```bash
+   dotnet run --project ../Lexicala.NET.Demo.Api/Lexicala.NET.Demo.Api.csproj
+   ```
 
-If you are developing a production application, we recommend updating the configuration to enable type-aware lint rules:
+2. **Node.js**: Ensure Node.js is installed (v16+)
 
-```js
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
+### Development
 
-      // Remove tseslint.configs.recommended and replace with this
-      tseslint.configs.recommendedTypeChecked,
-      // Alternatively, use this for stricter rules
-      tseslint.configs.strictTypeChecked,
-      // Optionally, add this for stylistic rules
-      tseslint.configs.stylisticTypeChecked,
+1. Navigate to the frontend folder:
+   ```bash
+   cd source/Demo/sense-sprint-web
+   ```
 
-      // Other configs...
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
+2. Install dependencies (required once):
+
+   **PowerShell:**
+   ```powershell
+   npm.cmd install
+   ```
+
+   **Bash / Command Prompt:**
+   ```bash
+   npm install
+   ```
+
+3. Start the dev server:
+
+   **PowerShell:**
+   ```powershell
+   npm.cmd run dev
+   ```
+
+   **Bash / Command Prompt:**
+   ```bash
+   npm run dev
+   ```
+
+4. Open in your browser:
+   - `http://localhost:5173`
+
+The Vite dev server proxies `/game/*` calls to `http://localhost:5000`, so game endpoints work without extra CORS setup.
+
+**Note:** PowerShell requires `npm.cmd` due to execution policies. If you see "npm is not recognized", ensure you're using `npm.cmd run dev` (PowerShell) or open Command Prompt / Git Bash instead.
+
+## Building for Production
+
+From the `sense-sprint-web` folder:
+
+```bash
+npm run build
 ```
 
-You can also install [eslint-plugin-react-x](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-x) and [eslint-plugin-react-dom](https://github.com/Rel1cx/eslint-react/tree/main/packages/plugins/eslint-plugin-react-dom) for React-specific lint rules:
+The production build outputs to the `dist/` folder, suitable for serving as a static site.
 
-```js
-// eslint.config.js
-import reactX from 'eslint-plugin-react-x'
-import reactDom from 'eslint-plugin-react-dom'
+## Tech Stack
 
-export default defineConfig([
-  globalIgnores(['dist']),
-  {
-    files: ['**/*.{ts,tsx}'],
-    extends: [
-      // Other configs...
-      // Enable lint rules for React
-      reactX.configs['recommended-typescript'],
-      // Enable lint rules for React DOM
-      reactDom.configs.recommended,
-    ],
-    languageOptions: {
-      parserOptions: {
-        project: ['./tsconfig.node.json', './tsconfig.app.json'],
-        tsconfigRootDir: import.meta.dirname,
-      },
-      // other options...
-    },
-  },
-])
-```
+- **React 19**: UI framework
+- **TypeScript 6**: Type safety
+- **Vite 8**: Build tool and dev server
+- **Tailwind-inspired CSS**: Custom responsive styling
+
+## Architecture
+
+The app is a single-component React application (`App.tsx`) with:
+- Local state management for game rounds, stats, and UI feedback
+- LocalStorage persistence for stats and active sessions
+- Automatic timeout detection for expired rounds
+- Session hydration on page load with stale-round detection
+
+## Game Rules
+
+1. **Start a Round**: Click "Start Round" to receive the first clue
+2. **Make Guesses**: Type your guess and press Enter or click "Submit Guess"
+3. **Request Clues**: Click "Next Clue" to reveal additional hints (score penalty applies)
+4. **Give Up**: Click "Give Up" to see the answer and move to the next round
+5. **Time Limit**: Each round expires after 60 seconds
+
+### Scoring
+
+- Base score starts at 50 points
+- Decreases as clues are revealed
+- Multiplied by your current streak bonus
+- Streak resets on:
+  - Incorrect guesses when no more clues are available
+  - Round timeout
+  - Giving up
+  - Starting a new word mid-game
+
+## Statistics Explained
+
+- **Total Points**: Cumulative score across all games
+- **High Score**: Best single-round payout (not cumulative)
+- **Win Streak**: Current consecutive wins
+- **Highest Streak**: Best consecutive wins in this session
+- **Games Played**: Total rounds started
+- **Wins/Losses**: Correct vs. incorrect final answers
+- **Expired/Give Ups**: Rounds lost to timeout or surrender
+- **Abandoned Rounds**: Rounds replaced by starting a new word
+- **Clues Requested**: Total extra clues revealed
+- **Avg. Clues/Round**: Average clues seen per game
+- **Avg. Extra Clues/Round**: Average requested clues per game
+
+## Resetting Data
+
+Click the "Reset Stats" button in the streak bonus panel to clear all saved statistics. The current active round is preserved.
+
+

--- a/source/Demo/sense-sprint-web/README.md
+++ b/source/Demo/sense-sprint-web/README.md
@@ -1,6 +1,10 @@
 # Sense Sprint
 
-A lexical word guessing game powered by the Lexicala API. Guess the hidden English word from progressively revealed linguistic clues using Fluky Search.
+A lexical word guessing game powered by the Lexicala API. The web demo includes `Sense Sprint` and `Translation Quiz`.
+
+## Token Usage Warning
+
+`Translation Quiz` consumes substantially more Lexicala API quota than `Sense Sprint`. Each round needs a random source word, a full entry lookup, and several extra lookups to assemble plausible wrong answers. If you are testing with a free evaluation subscription, use game mode 2 with care.
 
 ## Features
 

--- a/source/Demo/sense-sprint-web/package-lock.json
+++ b/source/Demo/sense-sprint-web/package-lock.json
@@ -13,6 +13,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^10.0.1",
+        "@playwright/test": "^1.59.1",
         "@types/node": "^24.12.2",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -573,6 +574,22 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@playwright/test": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.59.1.tgz",
+      "integrity": "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/@rolldown/binding-android-arm64": {
       "version": "1.0.0-rc.17",
       "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.17.tgz",
@@ -666,9 +683,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -686,9 +700,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -706,9 +717,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -726,9 +734,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -746,9 +751,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -766,9 +768,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -2022,9 +2021,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2046,9 +2042,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2070,9 +2063,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2094,9 +2084,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -2322,6 +2309,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.59.1.tgz",
+      "integrity": "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.59.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.59.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.59.1.tgz",
+      "integrity": "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/source/Demo/sense-sprint-web/package.json
+++ b/source/Demo/sense-sprint-web/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test:e2e": "playwright test"
   },
   "dependencies": {
     "react": "^19.2.5",
@@ -15,6 +16,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^10.0.1",
+    "@playwright/test": "^1.59.1",
     "@types/node": "^24.12.2",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",

--- a/source/Demo/sense-sprint-web/playwright.config.ts
+++ b/source/Demo/sense-sprint-web/playwright.config.ts
@@ -1,0 +1,26 @@
+import { defineConfig, devices } from '@playwright/test'
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  fullyParallel: true,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 1 : 0,
+  workers: process.env.CI ? 1 : undefined,
+  reporter: 'html',
+  use: {
+    baseURL: 'http://localhost:4173',
+    trace: 'on-first-retry',
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+  webServer: {
+    command: 'npm run preview',
+    url: 'http://localhost:4173',
+    reuseExistingServer: !process.env.CI,
+    timeout: 120_000,
+  },
+})

--- a/source/Demo/sense-sprint-web/src/App.css
+++ b/source/Demo/sense-sprint-web/src/App.css
@@ -268,6 +268,20 @@
   color: #64748b;
 }
 
+.wrong-history-label {
+  margin-top: 0.85rem;
+}
+
+.wrong-history-list li {
+  color: #7f1d1d;
+}
+
+.wrong-history-index {
+  color: #7f1d1d;
+  background: #fee2e2;
+  border-color: #fecaca;
+}
+
 .controls {
   display: grid;
   grid-template-columns: 1fr;

--- a/source/Demo/sense-sprint-web/src/App.css
+++ b/source/Demo/sense-sprint-web/src/App.css
@@ -735,3 +735,150 @@
     grid-template-columns: 1fr;
   }
 }
+
+/* ── Mode Tabs ─────────────────────────────────────────────────────────────── */
+
+.mode-tabs {
+  display: flex;
+  gap: 0.5rem;
+  margin-bottom: 1rem;
+}
+
+.mode-tab {
+  flex: 1;
+  border: 2px solid rgba(255, 255, 255, 0.25);
+  background: rgba(255, 255, 255, 0.08);
+  color: #d2dae5;
+  border-radius: 14px;
+  padding: 0.65rem 1rem;
+  font-size: 0.92rem;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 180ms ease, color 180ms ease, border-color 180ms ease;
+}
+
+.mode-tab:hover {
+  background: rgba(255, 255, 255, 0.15);
+  color: #fff;
+}
+
+.mode-tab-active {
+  background: rgba(255, 255, 255, 0.92);
+  color: #111827;
+  border-color: transparent;
+}
+
+/* ── Translation Quiz ──────────────────────────────────────────────────────── */
+
+.quiz-header {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.quiz-lang-label {
+  font-size: 0.88rem;
+  font-weight: 700;
+  color: var(--muted);
+  font-family: var(--mono);
+  white-space: nowrap;
+}
+
+.quiz-lang-select {
+  border: 2px solid #d9d9d9;
+  border-radius: 10px;
+  padding: 0.45rem 0.7rem;
+  font-size: 0.92rem;
+  font-family: var(--sans);
+  background: #fff;
+  cursor: pointer;
+}
+
+.quiz-lang-select:focus {
+  outline: none;
+  border-color: #2f80ed;
+}
+
+.quiz-word-panel {
+  padding: 1rem;
+  border-radius: 14px;
+  background: #fff;
+  border: 1px solid #e7e7e7;
+  text-align: center;
+  animation: popIn 280ms ease-out;
+}
+
+.quiz-word-label {
+  margin: 0 0 0.4rem;
+  font-size: 0.82rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  font-family: var(--mono);
+}
+
+.quiz-word {
+  margin: 0;
+  font-size: 2rem;
+  font-weight: 900;
+  color: #1f2937;
+}
+
+.quiz-word-empty {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.94rem;
+}
+
+.quiz-choices {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.7rem;
+}
+
+.quiz-choice {
+  background: #f8fafc;
+  border: 2px solid #e2e8f0;
+  color: #1f2937;
+  padding: 0.9rem 0.75rem;
+  font-size: 1rem;
+  font-weight: 700;
+  text-align: center;
+  border-radius: 14px;
+  cursor: pointer;
+  transition: background 140ms ease, border-color 140ms ease, transform 140ms ease;
+}
+
+.quiz-choice:hover:not(:disabled) {
+  background: #eff6ff;
+  border-color: #93c5fd;
+  transform: translateY(-2px);
+}
+
+.quiz-choice:disabled {
+  opacity: 0.7;
+  cursor: default;
+  transform: none;
+}
+
+.quiz-choice-correct {
+  background: #dcfce7 !important;
+  border-color: #22c55e !important;
+  color: #14532d !important;
+}
+
+.quiz-choice-wrong {
+  background: #fef2f2 !important;
+  border-color: #f87171 !important;
+  color: #7f1d1d !important;
+}
+
+@media (max-width: 480px) {
+  .quiz-choices {
+    grid-template-columns: 1fr;
+  }
+
+  .mode-tabs {
+    flex-direction: column;
+  }
+}

--- a/source/Demo/sense-sprint-web/src/App.css
+++ b/source/Demo/sense-sprint-web/src/App.css
@@ -53,6 +53,41 @@
   gap: 1rem;
 }
 
+.stats-collapsible {
+  margin-bottom: 0;
+}
+
+.stats-summary {
+  cursor: pointer;
+  padding: 0.6rem 0;
+  font-size: 0.85rem;
+  font-family: var(--mono);
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #6b7280;
+  user-select: none;
+  display: flex;
+  align-items: center;
+  font-weight: 600;
+  list-style: none;
+}
+
+.stats-summary::before {
+  content: '▶';
+  display: inline-block;
+  margin-right: 0.5rem;
+  transition: transform 200ms ease;
+  font-size: 0.72rem;
+}
+
+.stats-collapsible[open] > .stats-summary::before {
+  transform: rotate(90deg);
+}
+
+.stats-collapsible[open] > .stats-summary {
+  margin-bottom: 0.8rem;
+}
+
 .stats {
   display: grid;
   grid-template-columns: repeat(3, minmax(0, 1fr));
@@ -79,6 +114,85 @@
   margin: 0.28rem 0 0;
   font-size: 1.2rem;
   font-weight: 800;
+}
+
+.streak-panel {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(0, 1fr);
+  gap: 0.9rem;
+  align-items: start;
+  margin-top: 0.2rem;
+  padding: 0.95rem 1rem;
+  border-radius: 16px;
+  border: 1px solid rgba(255, 255, 255, 0.55);
+  background:
+    radial-gradient(circle at top right, rgba(255, 214, 102, 0.45), transparent 34%),
+    linear-gradient(135deg, rgba(17, 24, 39, 0.94), rgba(37, 99, 235, 0.78));
+  color: #f8fafc;
+}
+
+.streak-panel-win {
+  box-shadow: 0 14px 30px rgba(14, 165, 233, 0.2);
+}
+
+.streak-panel-major {
+  background:
+    radial-gradient(circle at 12% 18%, rgba(251, 191, 36, 0.6), transparent 24%),
+    radial-gradient(circle at 86% 22%, rgba(244, 114, 182, 0.36), transparent 30%),
+    linear-gradient(135deg, #14532d, #166534 40%, #1d4ed8 100%);
+  box-shadow: 0 16px 34px rgba(21, 128, 61, 0.32);
+}
+
+.streak-label {
+  margin: 0;
+  font-size: 0.72rem;
+  font-family: var(--mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.78);
+}
+
+.streak-value {
+  margin: 0.2rem 0 0;
+  font-size: clamp(1.4rem, 3vw, 2rem);
+  font-weight: 900;
+  line-height: 1.05;
+}
+
+.streak-copy {
+  margin: 0.45rem 0 0;
+  max-width: 58ch;
+  color: rgba(241, 245, 249, 0.88);
+}
+
+.streak-meta {
+  display: grid;
+  gap: 0.35rem;
+  padding: 0.8rem 0.9rem;
+  border-radius: 12px;
+  background: rgba(15, 23, 42, 0.26);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.streak-meta p {
+  font-size: 0.88rem;
+  color: rgba(248, 250, 252, 0.92);
+}
+
+.meta-actions {
+  display: flex;
+  justify-content: flex-end;
+  margin-top: -0.2rem;
+}
+
+.button-reset {
+  background: #111827;
+  color: #f8fafc;
+  border: 1px solid rgba(255, 255, 255, 0.18);
+}
+
+.button-reset:hover {
+  transform: translateY(-1px);
 }
 
 .clue {
@@ -159,6 +273,19 @@
   grid-template-columns: 1fr;
   gap: 0.7rem;
   margin-top: 1rem;
+}
+
+.language-picker {
+  display: grid;
+  gap: 0.35rem;
+}
+
+.language-picker span {
+  font-size: 0.74rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--muted);
+  font-family: var(--mono);
 }
 
 .input {
@@ -277,6 +404,22 @@
   animation: confettiDrift 1700ms linear infinite;
 }
 
+.status-major-win {
+  background: linear-gradient(110deg, #fef3c7 0%, #fde68a 18%, #dcfce7 48%, #bfdbfe 82%, #fef3c7 100%);
+  border-color: #f59e0b;
+  box-shadow: 0 0 0 2px rgba(245, 158, 11, 0.2), 0 16px 32px rgba(245, 158, 11, 0.25);
+}
+
+.status-major-win::after {
+  content: '';
+  position: absolute;
+  inset: -80% -10%;
+  background:
+    conic-gradient(from 180deg at 50% 50%, rgba(245, 158, 11, 0.16), transparent 20%, rgba(236, 72, 153, 0.16), transparent 45%, rgba(59, 130, 246, 0.18), transparent 70%, rgba(34, 197, 94, 0.18), transparent 100%);
+  animation: haloSpin 4200ms linear infinite;
+  pointer-events: none;
+}
+
 .victory-banner {
   position: relative;
   overflow: hidden;
@@ -308,6 +451,84 @@
   transform: translateX(-120%);
   pointer-events: none;
   animation: victorySheen 900ms ease-in-out infinite;
+}
+
+.victory-banner-major {
+  color: #3f2305;
+  background:
+    linear-gradient(90deg, rgba(253, 224, 71, 0.86), rgba(255, 255, 255, 0.92), rgba(147, 197, 253, 0.86)),
+    repeating-linear-gradient(-45deg, rgba(255, 255, 255, 0.2), rgba(255, 255, 255, 0.2) 12px, transparent 12px, transparent 24px);
+  border-color: rgba(245, 158, 11, 0.6);
+  box-shadow: 0 0 0 1px rgba(251, 191, 36, 0.38), 0 12px 26px rgba(245, 158, 11, 0.34);
+  animation: bannerSlide 580ms linear infinite, bannerBounce 520ms ease-in-out infinite alternate, majorBannerFlash 1200ms ease-in-out infinite;
+}
+
+.metrics-grid {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  gap: 0.7rem;
+  margin-top: 0.8rem;
+}
+
+.metrics-collapsible {
+  margin-top: 0.8rem;
+  border: 1px solid #d4d4d8;
+  border-radius: 12px;
+  background: #ffffff;
+  padding: 0.6rem 0.75rem;
+}
+
+.metrics-summary {
+  cursor: pointer;
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: #4b5563;
+  user-select: none;
+  display: flex;
+  align-items: center;
+  list-style: none;
+  font-weight: 600;
+}
+
+.metrics-summary::before {
+  content: '▶';
+  display: inline-block;
+  margin-right: 0.4rem;
+  transition: transform 200ms ease;
+  font-size: 0.68rem;
+}
+
+.metrics-collapsible[open] > .metrics-summary::before {
+  transform: rotate(90deg);
+}
+
+.metrics-collapsible[open] > .metrics-grid {
+  margin-top: 0.6rem;
+}
+
+.metric-card {
+  padding: 0.8rem 0.85rem;
+  border-radius: 14px;
+  background: rgba(255, 255, 255, 0.82);
+  border: 1px solid rgba(148, 163, 184, 0.28);
+}
+
+.metric-label {
+  margin: 0;
+  font-size: 0.72rem;
+  font-family: var(--mono);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--muted);
+}
+
+.metric-value {
+  margin: 0.28rem 0 0;
+  font-size: 1rem;
+  font-weight: 800;
+  color: #0f172a;
 }
 
 .footer {
@@ -440,6 +661,27 @@
   }
 }
 
+@keyframes haloSpin {
+  from {
+    transform: rotate(0deg);
+  }
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes majorBannerFlash {
+  0% {
+    filter: saturate(1);
+  }
+  50% {
+    filter: saturate(1.2) brightness(1.06);
+  }
+  100% {
+    filter: saturate(1);
+  }
+}
+
 @keyframes debugPulse {
   from {
     box-shadow: 0 0 0 0 rgba(14, 116, 144, 0.35);
@@ -454,8 +696,10 @@
 @media (prefers-reduced-motion: reduce) {
   .status-win,
   .status-win::before,
+  .status-major-win::after,
   .victory-banner,
-  .victory-banner::after {
+  .victory-banner::after,
+  .victory-banner-major {
     animation: none;
   }
 }
@@ -465,11 +709,29 @@
     padding: 1.2rem 0.75rem 2rem;
   }
 
+  .stats-summary {
+    display: flex;
+  }
+
   .stats {
     grid-template-columns: 1fr;
   }
 
+  .streak-panel {
+    grid-template-columns: 1fr;
+  }
+
+  .metrics-grid {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
   .debug-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 520px) {
+  .metrics-grid {
     grid-template-columns: 1fr;
   }
 }

--- a/source/Demo/sense-sprint-web/src/App.tsx
+++ b/source/Demo/sense-sprint-web/src/App.tsx
@@ -104,6 +104,7 @@ type GameStats = {
 type StoredSession = {
   round: ActiveRound
   revealedClues: string[]
+  wrongGuesses: string[]
   guess: string
 }
 
@@ -264,6 +265,9 @@ function loadStoredSession(): StoredSession | null {
       revealedClues: Array.isArray(parsed.revealedClues)
         ? parsed.revealedClues.filter((item): item is string => typeof item === 'string')
         : [parsed.round.clue],
+      wrongGuesses: Array.isArray(parsed.wrongGuesses)
+        ? parsed.wrongGuesses.filter((item): item is string => typeof item === 'string')
+        : [],
       guess: typeof parsed.guess === 'string' ? parsed.guess : '',
     }
   } catch {
@@ -327,6 +331,104 @@ function formatAverage(value: number): string {
   return value.toFixed(1)
 }
 
+// ─── Languages Caching (Tier 1: ETag + localStorage) ──────────────────────────
+// Caches the /languages response to eliminate redundant API calls
+// Strategy: Check session cache → localStorage (with ETag) → API fallback
+
+type CachedLanguages = {
+  data: LanguagesResponse
+  etag?: string
+  timestamp: number
+}
+
+let sessionLanguagesCache: CachedLanguages | null = null
+
+async function loadLanguagesWithCaching(): Promise<LanguagesResponse> {
+  // 1️⃣ Check session-level cache (fastest, zero API calls if hit)
+  if (sessionLanguagesCache) {
+    return sessionLanguagesCache.data
+  }
+
+  // 2️⃣ Check localStorage (fast, but may need ETag refresh)
+  let storedCache: CachedLanguages | null = null
+  let headers: HeadersInit = {}
+
+  if (typeof window !== 'undefined') {
+    const stored = window.localStorage.getItem('lexicala-languages-cache-v1')
+    if (stored) {
+      try {
+        storedCache = JSON.parse(stored) as CachedLanguages
+        // If we have ETag from previous fetch, use it for conditional request
+        if (storedCache.etag) {
+          headers['If-None-Match'] = storedCache.etag
+        }
+      } catch {
+        // Invalid cached data, clear it
+        window.localStorage.removeItem('lexicala-languages-cache-v1')
+        window.localStorage.removeItem('lexicala-languages-etag-v1')
+      }
+    }
+  }
+
+  // 3️⃣ Fetch from API (with ETag for conditional request)
+  try {
+    const response = await fetch('/languages', {
+      headers: Object.keys(headers).length > 0 ? headers : undefined,
+    })
+
+    let result: LanguagesResponse
+
+    if (response.status === 304 && storedCache) {
+      // 304 Not Modified: Use cached data, content hasn't changed
+      result = storedCache.data
+    } else if (response.ok) {
+      // 200 OK: Fresh response
+      result = (await response.json()) as LanguagesResponse
+
+      // Extract ETag for next request
+      const etag = response.headers.get('ETag')
+      const cacheData: CachedLanguages = {
+        data: result,
+        etag: etag ?? undefined,
+        timestamp: Date.now(),
+      }
+
+      // Store in session cache
+      sessionLanguagesCache = cacheData
+
+      // Store in localStorage for cross-session persistence
+      if (typeof window !== 'undefined') {
+        try {
+          window.localStorage.setItem('lexicala-languages-cache-v1', JSON.stringify(cacheData))
+        } catch (e) {
+          // localStorage may be full or disabled, just skip persistence
+          console.warn('Failed to cache languages to localStorage:', e)
+        }
+      }
+    } else {
+      // Unexpected status code; if we have cached data, use it
+      if (storedCache) {
+        result = storedCache.data
+      } else {
+        throw new Error(`HTTP ${response.status}`)
+      }
+    }
+
+    // Cache in session
+    sessionLanguagesCache = { data: result, etag: storedCache?.etag, timestamp: Date.now() }
+    return result
+  } catch (error) {
+    // API failed; try to use cached version as fallback
+    if (storedCache) {
+      sessionLanguagesCache = storedCache
+      return storedCache.data
+    }
+
+    // No fallback available, throw error
+    throw error
+  }
+}
+
 const api = {
   async createRound(language: string): Promise<ApiResult<CreateRoundResponse>> {
     const response = await fetch('/game/sense-sprint/rounds', {
@@ -339,8 +441,11 @@ const api = {
   },
 
   async languages(): Promise<ApiResult<LanguagesResponse>> {
-    const response = await fetch('/languages')
-    return parseResponse<LanguagesResponse>(response)
+    const data = await loadLanguagesWithCaching()
+    return {
+      data,
+      rateLimit: null, // Cached requests don't consume rate limit quota
+    }
   },
 
   async nextClue(roundId: string): Promise<ApiResult<NextClueResponse>> {
@@ -453,10 +558,12 @@ function SenseSprint() {
   const [timeLeft, setTimeLeft] = useState(0)
   const [rateLimitDebug, setRateLimitDebug] = useState<RateLimitDebug | null>(null)
   const [revealedClues, setRevealedClues] = useState<string[]>([])
+  const [wrongGuesses, setWrongGuesses] = useState<string[]>([])
   const [debugCallCount, setDebugCallCount] = useState(0)
   const [debugLastUpdated, setDebugLastUpdated] = useState('-')
   const [debugPulseTick, setDebugPulseTick] = useState(0)
   const [hasHydratedSession, setHasHydratedSession] = useState(false)
+  const expiryHandledRef = useRef(false)
   const [statsOpen, setStatsOpen] = useState(() => {
     if (typeof window === 'undefined') return true
     return window.innerWidth >= 760
@@ -476,6 +583,10 @@ function SenseSprint() {
     const loadLanguages = async () => {
       setLoadingLanguages(true)
       try {
+        // Calls loadLanguagesWithCaching():
+        // 1️⃣ Session cache (no API call if loaded in this session)
+        // 2️⃣ localStorage with ETag (304 Not Modified if unchanged)
+        // 3️⃣ API fallback, saves ETag for next time
         const languageResult = await api.languages()
         if (isCancelled) {
           return
@@ -555,6 +666,7 @@ function SenseSprint() {
     setRound(storedSession.round)
     setSelectedLanguage(storedSession.round.language)
     setRevealedClues(storedSession.revealedClues.length > 0 ? storedSession.revealedClues : [storedSession.round.clue])
+    setWrongGuesses(storedSession.wrongGuesses)
     setGuess(storedSession.guess)
     setTimeLeft(getSecondsRemaining(storedSession.round.expiresAtUtc))
     setStatusMessage('Round restored. Pick up where you left off.')
@@ -574,11 +686,16 @@ function SenseSprint() {
     const sessionPayload: StoredSession = {
       round,
       revealedClues: revealedClues.length > 0 ? revealedClues : [round.clue],
+      wrongGuesses,
       guess,
     }
 
     window.localStorage.setItem(sessionStorageKey, JSON.stringify(sessionPayload))
-  }, [round, revealedClues, guess])
+  }, [round, revealedClues, wrongGuesses, guess])
+
+  useEffect(() => {
+    expiryHandledRef.current = false
+  }, [round?.roundId, round?.roundStatus])
 
   useEffect(() => {
     if (!round || round.roundStatus !== 'in-progress') {
@@ -592,6 +709,12 @@ function SenseSprint() {
       if (diff > 0) {
         return
       }
+
+      if (expiryHandledRef.current) {
+        return
+      }
+
+      expiryHandledRef.current = true
 
       // Auto-giveup when timer expires to reveal answer
       setLoading(true)
@@ -629,10 +752,42 @@ function SenseSprint() {
           clearStoredSession()
         })
         .catch((err) => {
-          console.error('Failed to process round expiry:', err)
-          setError(String(err))
-          setStatusMessage('Round ended but could not retrieve answer.')
-          setFeedbackTone('error')
+          const message = err instanceof Error ? err.message : String(err)
+          const isRoundAlreadyGone = message.toLowerCase().includes('round not found')
+
+          const streakBeforeExpiry = stats.currentStreak
+
+          setRound((current) => {
+            if (!current || current.roundId !== round.roundId) {
+              return current
+            }
+
+            return {
+              ...current,
+              roundStatus: 'expired',
+            }
+          })
+
+          setStats((current) => ({
+            ...current,
+            roundsExpired: current.roundsExpired + 1,
+            currentStreak: 0,
+            lastPlayedAt: new Date().toISOString(),
+          }))
+
+          setStatusMessage(
+            streakBeforeExpiry > 0
+              ? `Time expired. ${streakBeforeExpiry}-win streak reset.`
+              : 'Time expired. Start a new round.',
+          )
+          setFeedbackTone('warning')
+          setGuess('')
+          setError('')
+          clearStoredSession()
+
+          if (!isRoundAlreadyGone) {
+            console.warn('Timer expiry fallback: round marked expired without give-up payload.', err)
+          }
         })
         .finally(() => {
           setLoading(false)
@@ -664,7 +819,8 @@ function SenseSprint() {
   const averageRequestedCluesPerRound = stats.roundsStarted > 0 ? stats.cluesRequested / stats.roundsStarted : 0
   const nextCelebrationAt = Math.floor(stats.currentStreak / 5) * 5 + 5
   const winsUntilCelebration = nextCelebrationAt - stats.currentStreak
-  const selectedLanguageName = languageOptions.find((option) => option.code === selectedLanguage)?.name ?? selectedLanguage.toUpperCase()
+  const safeSelectedLanguage = typeof selectedLanguage === 'string' && selectedLanguage.trim().length > 0 ? selectedLanguage : 'en'
+  const selectedLanguageName = languageOptions.find((option) => option.code === safeSelectedLanguage)?.name ?? safeSelectedLanguage.toUpperCase()
 
   function refreshDebug(rateLimit: RateLimitDebug | null): void {
     setDebugCallCount((current) => current + 1)
@@ -678,6 +834,7 @@ function SenseSprint() {
   async function startRound(): Promise<void> {
     const isAbandoningActiveRound = round?.roundStatus === 'in-progress'
     const streakBeforeReset = stats.currentStreak
+    const requestedLanguage = safeSelectedLanguage
 
     if (isAbandoningActiveRound) {
       const confirmed = window.confirm(
@@ -695,11 +852,12 @@ function SenseSprint() {
     setError('')
 
     try {
-      const createdResult = await api.createRound(selectedLanguage)
+      const createdResult = await api.createRound(requestedLanguage)
       const created = createdResult.data
+      const resolvedLanguage = typeof created.language === 'string' && created.language.trim().length > 0 ? created.language : requestedLanguage
       setRound({
         roundId: created.roundId,
-        language: created.language,
+        language: resolvedLanguage,
         clue: created.clue,
         clueIndex: created.clueIndex,
         maxClues: created.maxClues,
@@ -708,8 +866,9 @@ function SenseSprint() {
         roundStatus: 'in-progress',
         answer: null,
       })
-      setSelectedLanguage(created.language)
+      setSelectedLanguage(resolvedLanguage)
       setRevealedClues([created.clue])
+      setWrongGuesses([])
       setTimeLeft(getSecondsRemaining(created.expiresAtUtc))
       refreshDebug(createdResult.rateLimit ?? created.rateLimit)
 
@@ -797,12 +956,13 @@ function SenseSprint() {
     }
 
     const streakBeforeGuess = stats.currentStreak
+    const submittedGuess = guess.trim()
 
     setLoading(true)
     setError('')
 
     try {
-      const guessResult = await api.guess(round.roundId, guess)
+      const guessResult = await api.guess(round.roundId, submittedGuess)
       const result = guessResult.data
 
       setStats((current) => ({
@@ -833,6 +993,8 @@ function SenseSprint() {
             : `Correct! +${awardedPoints} points. Streak is now ${nextStreak}.`,
         )
         setFeedbackTone('success')
+      } else {
+        setWrongGuesses((current) => [...current, submittedGuess])
       }
 
       setRound((current) => {
@@ -1037,6 +1199,20 @@ function SenseSprint() {
             ) : (
               <p className="clue-history-empty">No clues revealed yet.</p>
             )}
+
+            <p className="clue-history-label wrong-history-label">Wrong answers entered</p>
+            {wrongGuesses.length > 0 ? (
+              <ol className="clue-history-list wrong-history-list">
+                {wrongGuesses.map((wrongGuess, index) => (
+                  <li key={`${index}-${wrongGuess}`}>
+                    <span className="clue-history-index wrong-history-index">#{index + 1}</span>
+                    <span>{wrongGuess}</span>
+                  </li>
+                ))}
+              </ol>
+            ) : (
+              <p className="clue-history-empty">No wrong answers yet.</p>
+            )}
           </div>
         </div>
 
@@ -1210,6 +1386,10 @@ function TranslationQuiz() {
     const loadLanguages = async () => {
       setLoadingQuizLanguages(true)
       try {
+        // Calls loadLanguagesWithCaching():
+        // 1️⃣ Session cache (no API call if loaded in this session)
+        // 2️⃣ localStorage with ETag (304 Not Modified if unchanged)
+        // 3️⃣ API fallback, saves ETag for next time
         const result = await api.languages()
         if (isCancelled) return
 

--- a/source/Demo/sense-sprint-web/src/App.tsx
+++ b/source/Demo/sense-sprint-web/src/App.tsx
@@ -379,8 +379,9 @@ async function loadLanguagesWithCaching(): Promise<LanguagesResponse> {
     let result: LanguagesResponse
 
     if (response.status === 304 && storedCache) {
-      // 304 Not Modified: Use cached data, content hasn't changed
+      // 304 Not Modified: Use cached data, content hasn't changed; preserve existing ETag
       result = storedCache.data
+      sessionLanguagesCache = storedCache
     } else if (response.ok) {
       // 200 OK: Fresh response
       result = (await response.json()) as LanguagesResponse
@@ -393,7 +394,7 @@ async function loadLanguagesWithCaching(): Promise<LanguagesResponse> {
         timestamp: Date.now(),
       }
 
-      // Store in session cache
+      // Store in session cache with the freshly fetched ETag
       sessionLanguagesCache = cacheData
 
       // Store in localStorage for cross-session persistence
@@ -409,13 +410,12 @@ async function loadLanguagesWithCaching(): Promise<LanguagesResponse> {
       // Unexpected status code; if we have cached data, use it
       if (storedCache) {
         result = storedCache.data
+        sessionLanguagesCache = storedCache
       } else {
         throw new Error(`HTTP ${response.status}`)
       }
     }
 
-    // Cache in session
-    sessionLanguagesCache = { data: result, etag: storedCache?.etag, timestamp: Date.now() }
     return result
   } catch (error) {
     // API failed; try to use cached version as fallback

--- a/source/Demo/sense-sprint-web/src/App.tsx
+++ b/source/Demo/sense-sprint-web/src/App.tsx
@@ -1,6 +1,9 @@
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import './App.css'
 
+// ─── Shared types ─────────────────────────────────────────────────────────────
+
+type GameMode = 'sense-sprint' | 'translation-quiz'
 type RoundStatus = 'in-progress' | 'won' | 'lost' | 'expired' | 'completed'
 type FeedbackTone = 'info' | 'success' | 'warning' | 'error'
 type CelebrationLevel = 'none' | 'win' | 'major'
@@ -69,6 +72,7 @@ type LanguagesResponse = {
   resources: {
     global?: {
       source_languages?: string[]
+      target_languages?: string[]
     }
   }
 }
@@ -103,8 +107,52 @@ type StoredSession = {
   guess: string
 }
 
+// ─── Translation Quiz types ───────────────────────────────────────────────────
+
+type ActiveQuizRound = {
+  roundId: string
+  sourceWord: string
+  sourceLanguage: string
+  targetLanguage: string
+  choices: string[]
+  expiresAtUtc: string
+  roundStatus: RoundStatus
+  correctAnswer: string | null
+  selectedChoice: string | null
+}
+
+type CreateQuizRoundResponse = {
+  roundId: string
+  sourceWord: string
+  sourceLanguage: string
+  targetLanguage: string
+  choices: string[]
+  expiresAtUtc: string
+  roundSeconds: number
+  rateLimit: RateLimitDebug | null
+}
+
+type QuizAnswerResponse = {
+  roundId: string
+  isCorrect: boolean
+  roundStatus: RoundStatus
+  awardedPoints: number
+  correctAnswer: string
+  message: string | null
+}
+
+type QuizStats = {
+  currentScore: number
+  highScore: number
+  roundsPlayed: number
+  roundsWon: number
+  currentStreak: number
+  highestStreak: number
+}
+
 const statsStorageKey = 'sense-sprint-stats-v1'
 const sessionStorageKey = 'sense-sprint-session-v1'
+const quizStatsStorageKey = 'translation-quiz-stats-v1'
 
 const defaultStats: GameStats = {
   currentScore: 0,
@@ -167,6 +215,34 @@ function isValidStoredRound(value: unknown): value is ActiveRound {
   )
 }
 
+// ─── Translation Quiz stats helpers ──────────────────────────────────────────
+
+const defaultQuizStats: QuizStats = {
+  currentScore: 0,
+  highScore: 0,
+  roundsPlayed: 0,
+  roundsWon: 0,
+  currentStreak: 0,
+  highestStreak: 0,
+}
+
+function loadQuizStats(): QuizStats {
+  if (typeof window === 'undefined') return { ...defaultQuizStats }
+  const raw = window.localStorage.getItem(quizStatsStorageKey)
+  if (!raw) return { ...defaultQuizStats }
+  try {
+    return { ...defaultQuizStats, ...(JSON.parse(raw) as Partial<QuizStats>) }
+  } catch {
+    return { ...defaultQuizStats }
+  }
+}
+
+function saveQuizStats(stats: QuizStats): void {
+  if (typeof window !== 'undefined') {
+    window.localStorage.setItem(quizStatsStorageKey, JSON.stringify(stats))
+  }
+}
+
 function loadStoredSession(): StoredSession | null {
   if (typeof window === 'undefined') {
     return null
@@ -204,7 +280,7 @@ function clearStoredSession(): void {
 }
 
 function getSecondsRemaining(expiresAtUtc: string): number {
-  return Math.max(0, Math.floor((new Date(expiresAtUtc).getTime() - Date.now()) / 1000))
+  return Math.max(0, Math.ceil((new Date(expiresAtUtc).getTime() - Date.now()) / 1000))
 }
 
 function getStreakMultiplier(streak: number): number {
@@ -294,6 +370,37 @@ const api = {
 
     return parseResponse<GuessResponse>(response)
   },
+
+  async createQuizRound(targetLanguage?: string): Promise<ApiResult<CreateQuizRoundResponse>> {
+    const url = targetLanguage
+      ? `/game/translation-quiz/rounds?targetLanguage=${encodeURIComponent(targetLanguage)}`
+      : '/game/translation-quiz/rounds'
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    return parseResponse<CreateQuizRoundResponse>(response)
+  },
+
+  async submitQuizAnswer(roundId: string, choice: string): Promise<ApiResult<QuizAnswerResponse>> {
+    const response = await fetch(`/game/translation-quiz/rounds/${roundId}/answer`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ choice }),
+    })
+
+    return parseResponse<QuizAnswerResponse>(response)
+  },
+
+  async expireQuizRound(roundId: string): Promise<ApiResult<QuizAnswerResponse>> {
+    const response = await fetch(`/game/translation-quiz/rounds/${roundId}/expire`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+    })
+
+    return parseResponse<QuizAnswerResponse>(response)
+  },
 }
 
 function getRateLimitFromHeaders(headers: Headers): RateLimitDebug | null {
@@ -330,7 +437,9 @@ async function parseResponse<T>(response: Response): Promise<ApiResult<T>> {
   }
 }
 
-function App() {
+// ─── SenseSprint component ────────────────────────────────────────────────────
+
+function SenseSprint() {
   const [round, setRound] = useState<ActiveRound | null>(null)
   const [guess, setGuess] = useState('')
   const [selectedLanguage, setSelectedLanguage] = useState('en')
@@ -853,24 +962,15 @@ function App() {
   }
 
   return (
-    <main className="page">
-      <header className="header">
-        <span className="badge">Lexicala Game</span>
-        <h1 className="title">Sense Sprint</h1>
-        <p className="subtitle">
-          Guess the hidden English word from lexical clues generated with Fluky Search.
-        </p>
-      </header>
-
-      <section className="panel grid">
-        <details open={statsOpen} onToggle={(e) => setStatsOpen(e.currentTarget.open)} className="stats-collapsible">
-          <summary className="stats-summary">Performance Snapshot</summary>
-          <div className="stats">
-          <article className="kpi">
-            <p className="kpi-label">Total Points</p>
-            <p className="kpi-value">{stats.currentScore}</p>
-          </article>
-          <article className="kpi">
+    <section className="panel grid">
+      <details open={statsOpen} onToggle={(e) => setStatsOpen(e.currentTarget.open)} className="stats-collapsible">
+        <summary className="stats-summary">Performance Snapshot</summary>
+        <div className="stats">
+        <article className="kpi">
+          <p className="kpi-label">Total Points</p>
+          <p className="kpi-value">{stats.currentScore}</p>
+        </article>
+        <article className="kpi">
             <p className="kpi-label">High Score</p>
             <p className="kpi-value">{stats.highScore}</p>
           </article>
@@ -1076,7 +1176,393 @@ function App() {
             </p>
           </div>
         </details>
-      </section>
+    </section>
+  )
+}
+
+// ─── Translation Quiz component ───────────────────────────────────────────────
+
+function TranslationQuiz() {
+  const [round, setRound] = useState<ActiveQuizRound | null>(null)
+  const [targetLanguage, setTargetLanguage] = useState('')
+  const [quizLanguageOptions, setQuizLanguageOptions] = useState<LanguageOption[]>([])
+  const [loadingQuizLanguages, setLoadingQuizLanguages] = useState(true)
+  const [statusMessage, setStatusMessage] = useState('Choose a target language (or leave on Random) and start a round.')
+  const [feedbackTone, setFeedbackTone] = useState<FeedbackTone>('info')
+  const [stats, setStats] = useState<QuizStats>(() => loadQuizStats())
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState('')
+  const [timeLeft, setTimeLeft] = useState(0)
+  const [rateLimitDebug, setRateLimitDebug] = useState<RateLimitDebug | null>(null)
+  const [debugCallCount, setDebugCallCount] = useState(0)
+  const [debugLastUpdated, setDebugLastUpdated] = useState('-')
+  const [debugPulseTick, setDebugPulseTick] = useState(0)
+  const expiryHandledRef = useRef(false)
+
+  useEffect(() => {
+    saveQuizStats(stats)
+  }, [stats])
+
+  // Load available target languages from the API
+  useEffect(() => {
+    let isCancelled = false
+
+    const loadLanguages = async () => {
+      setLoadingQuizLanguages(true)
+      try {
+        const result = await api.languages()
+        if (isCancelled) return
+
+        const languageNames = result.data.language_names ?? {}
+        // Prefer explicit target_languages; fall back to source_languages, exclude 'en'
+        const rawList = [
+          ...new Set(
+            (result.data.resources?.global?.target_languages ?? result.data.resources?.global?.source_languages ?? [])
+              .map((code) => code.trim().toLowerCase())
+              .filter((code) => code.length > 0 && code !== 'en'),
+          ),
+        ].sort()
+        const options = rawList.map((code) => ({ code, name: languageNames[code] ?? code.toUpperCase() }))
+        setQuizLanguageOptions(options)
+      } catch {
+        if (!isCancelled) {
+          setQuizLanguageOptions([
+            { code: 'de', name: 'German' },
+            { code: 'nl', name: 'Dutch' },
+            { code: 'fr', name: 'French' },
+            { code: 'es', name: 'Spanish' },
+          ])
+        }
+      } finally {
+        if (!isCancelled) setLoadingQuizLanguages(false)
+      }
+    }
+
+    void loadLanguages()
+    return () => { isCancelled = true }
+  }, [])
+
+  useEffect(() => {
+    if (!round || round.roundStatus !== 'in-progress') {
+      return
+    }
+
+    const timer = window.setInterval(() => {
+      const diff = Math.max(0, Math.ceil((new Date(round.expiresAtUtc).getTime() - Date.now()) / 1000))
+      setTimeLeft(diff)
+    }, 250)
+
+    return () => window.clearInterval(timer)
+  }, [round])
+
+  // Reveal answer when timer expires
+  useEffect(() => {
+    if (timeLeft !== 0 || round?.roundStatus !== 'in-progress' || expiryHandledRef.current) {
+      return
+    }
+
+    expiryHandledRef.current = true
+    const roundId = round.roundId
+
+    setLoading(true)
+    api
+      .expireQuizRound(roundId)
+      .then((result) => {
+        const data = result.data
+        setRound((current) => {
+          if (!current) return current
+          return { ...current, roundStatus: data.roundStatus, correctAnswer: data.correctAnswer }
+        })
+        if (result.rateLimit) setRateLimitDebug(result.rateLimit)
+        setDebugCallCount((n) => n + 1)
+        setDebugLastUpdated(new Date().toLocaleTimeString())
+        setDebugPulseTick((n) => n + 1)
+        setStatusMessage(`Time's up! The correct answer was: ${data.correctAnswer}`)
+        setFeedbackTone('warning')
+        setStats((current) => ({ ...current, currentStreak: 0 }))
+      })
+      .catch(() => {
+        setRound((current) => {
+          if (!current) return current
+          return { ...current, roundStatus: 'expired' }
+        })
+        setStatusMessage("Time's up!")
+        setFeedbackTone('warning')
+        setStats((current) => ({ ...current, currentStreak: 0 }))
+      })
+      .finally(() => {
+        setLoading(false)
+      })
+    // expiryHandledRef guards against re-entry; loading is intentionally omitted
+    // from deps to prevent the effect cleanup from cancelling an in-flight API call.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [timeLeft, round?.roundStatus, round?.roundId])
+
+  function getLanguageName(code: string): string {
+    return quizLanguageOptions.find((o) => o.code === code)?.name ?? code.toUpperCase()
+  }
+
+  function refreshDebug(rateLimit: RateLimitDebug | null): void {
+    setDebugCallCount((current) => current + 1)
+    setDebugLastUpdated(new Date().toLocaleTimeString())
+    setDebugPulseTick((current) => current + 1)
+    if (rateLimit) {
+      setRateLimitDebug(rateLimit)
+    }
+  }
+
+  async function startRound(): Promise<void> {
+    setLoading(true)
+    setError('')
+    expiryHandledRef.current = false
+
+    try {
+      // Empty string → server picks a random language
+      const result = await api.createQuizRound(targetLanguage || undefined)
+      const created = result.data
+      setRound({
+        roundId: created.roundId,
+        sourceWord: created.sourceWord,
+        sourceLanguage: created.sourceLanguage,
+        targetLanguage: created.targetLanguage,
+        choices: created.choices,
+        expiresAtUtc: created.expiresAtUtc,
+        roundStatus: 'in-progress',
+        correctAnswer: null,
+        selectedChoice: null,
+      })
+      setTimeLeft(Math.max(0, Math.ceil((new Date(created.expiresAtUtc).getTime() - Date.now()) / 1000)))
+      refreshDebug(result.rateLimit ?? created.rateLimit)
+      setStats((current) => ({ ...current, roundsPlayed: current.roundsPlayed + 1 }))
+      setStatusMessage(`Choose the correct ${getLanguageName(created.targetLanguage)} translation.`)
+      setFeedbackTone('info')
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unable to start round.'
+      setError(message)
+      setFeedbackTone('error')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  async function submitChoice(choice: string): Promise<void> {
+    if (!round || round.roundStatus !== 'in-progress' || loading) {
+      return
+    }
+
+    setLoading(true)
+    setError('')
+
+    try {
+      const result = await api.submitQuizAnswer(round.roundId, choice)
+      const data = result.data
+
+      if (data.isCorrect) {
+        const nextStreak = stats.currentStreak + 1
+        setStats((current) => ({
+          ...current,
+          currentScore: current.currentScore + data.awardedPoints,
+          highScore: Math.max(current.highScore, data.awardedPoints),
+          roundsWon: current.roundsWon + 1,
+          currentStreak: nextStreak,
+          highestStreak: Math.max(current.highestStreak, nextStreak),
+        }))
+        setStatusMessage(`Correct! +${data.awardedPoints} ${data.awardedPoints === 1 ? 'point' : 'points'}. The translation is: ${data.correctAnswer}`)
+        setFeedbackTone('success')
+      } else {
+        setStats((current) => ({ ...current, currentStreak: 0 }))
+        if (data.roundStatus === 'expired') {
+          setStatusMessage(`Time's up! The correct answer was: ${data.correctAnswer}`)
+        } else {
+          setStatusMessage(`Incorrect. The correct answer was: ${data.correctAnswer}`)
+        }
+        setFeedbackTone('warning')
+      }
+
+      setRound((current) => {
+        if (!current) return current
+        return {
+          ...current,
+          roundStatus: data.roundStatus,
+          correctAnswer: data.correctAnswer,
+          selectedChoice: choice,
+        }
+      })
+      refreshDebug(result.rateLimit)
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Unable to submit answer.'
+      setError(message)
+      setFeedbackTone('error')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  const canAnswer = Boolean(round && round.roundStatus === 'in-progress' && !loading)
+  const usedRequests = rateLimitDebug ? Math.max(0, rateLimitDebug.limit - rateLimitDebug.limitRemaining) : null
+
+  return (
+    <section className="panel grid">
+      <div className="quiz-header">
+        <label className="quiz-lang-label" htmlFor="quiz-target-language">
+          Translate to:
+        </label>
+        <select
+          id="quiz-target-language"
+          className="quiz-lang-select"
+          value={targetLanguage}
+          onChange={(e) => setTargetLanguage(e.target.value)}
+          disabled={loading || loadingQuizLanguages}
+        >
+          <option value="">Random (any language)</option>
+          {quizLanguageOptions.map((option) => (
+            <option key={option.code} value={option.code}>
+              {option.name} ({option.code})
+            </option>
+          ))}
+        </select>
+      </div>
+
+      <div className="stats">
+        <article className="kpi">
+          <p className="kpi-label">Total Points</p>
+          <p className="kpi-value">{stats.currentScore}</p>
+        </article>
+        <article className="kpi">
+          <p className="kpi-label">High Score</p>
+          <p className="kpi-value">{stats.highScore}</p>
+        </article>
+        <article className="kpi">
+          <p className="kpi-label">Win Streak 🔥</p>
+          <p className="kpi-value">{stats.currentStreak}</p>
+        </article>
+        <article className="kpi">
+          <p className="kpi-label">Best Streak</p>
+          <p className="kpi-value">{stats.highestStreak}</p>
+        </article>
+        <article className="kpi">
+          <p className="kpi-label">Rounds</p>
+          <p className="kpi-value">{stats.roundsPlayed}</p>
+        </article>
+        <article className="kpi">
+          <p className="kpi-label">Time Left</p>
+          <p className="kpi-value">{round ? `${timeLeft}s` : '-'}</p>
+        </article>
+      </div>
+
+      <div className="quiz-word-panel">
+        {round ? (
+          <>
+            <p className="quiz-word-label">What is the {getLanguageName(round.targetLanguage)} translation of:</p>
+            <p className="quiz-word">{round.sourceWord}</p>
+          </>
+        ) : (
+          <p className="quiz-word-empty">No active round yet.</p>
+        )}
+      </div>
+
+      <div className="quiz-choices" aria-label="Translation choices">
+        {round?.choices.map((choice) => {
+          const isSelected = round.selectedChoice === choice
+          const isCorrect = round.correctAnswer === choice
+          const isFinished = round.roundStatus !== 'in-progress'
+          let choiceClass = 'button quiz-choice'
+          if (isFinished) {
+            if (isCorrect) choiceClass += ' quiz-choice-correct'
+            else if (isSelected) choiceClass += ' quiz-choice-wrong'
+          }
+          return (
+            <button
+              key={choice}
+              className={choiceClass}
+              onClick={() => void submitChoice(choice)}
+              disabled={!canAnswer}
+            >
+              {choice}
+            </button>
+          )
+        }) ?? <p className="quiz-word-empty">Start a round to see choices.</p>}
+      </div>
+
+      <div className="actions">
+        <button className="button button-ghost" onClick={() => void startRound()} disabled={loading}>
+          {round ? 'New Round' : 'Start Round'}
+        </button>
+      </div>
+
+      <p className={`status status-${feedbackTone} ${round?.roundStatus === 'won' ? 'status-win' : ''}`} role="status" aria-live="polite">
+        <strong>Status:</strong> {statusMessage}
+      </p>
+      {round?.roundStatus === 'won' ? <p className="victory-banner">Correct! Streak: {stats.currentStreak} 🔥</p> : null}
+      {error ? <p className="error">{error}</p> : null}
+
+      <details className={`debug-panel ${debugPulseTick % 2 === 0 ? 'debug-panel-pulse-a' : 'debug-panel-pulse-b'}`}>
+        <summary>Debug Info</summary>
+        <div className="debug-grid">
+          <p>
+            <strong>Round ID:</strong> {round?.roundId ?? '-'}
+          </p>
+          <p>
+            <strong>Round Status:</strong> {round?.roundStatus ?? '-'}
+          </p>
+          <p>
+            <strong>Rate Limit:</strong> {rateLimitDebug ? `${rateLimitDebug.limitRemaining}/${rateLimitDebug.limit} remaining` : 'not available yet'}
+          </p>
+          <p>
+            <strong>Rate Used:</strong> {usedRequests ?? '-'}
+          </p>
+          <p>
+            <strong>Rate Reset (sec):</strong> {rateLimitDebug?.resetSeconds ?? '-'}
+          </p>
+          <p>
+            <strong>API Calls:</strong> {debugCallCount}
+          </p>
+          <p>
+            <strong>Debug Updated:</strong> {debugLastUpdated}
+          </p>
+        </div>
+      </details>
+    </section>
+  )
+}
+
+// ─── App ──────────────────────────────────────────────────────────────────────
+
+function App() {
+  const [gameMode, setGameMode] = useState<GameMode>('sense-sprint')
+
+  return (
+    <main className="page">
+      <header className="header">
+        <span className="badge">Lexicala Game</span>
+        <h1 className="title">{gameMode === 'sense-sprint' ? 'Sense Sprint' : 'Translation Quiz'}</h1>
+        <p className="subtitle">
+          {gameMode === 'sense-sprint'
+            ? 'Guess the hidden word from lexical clues generated with Fluky Search.'
+            : 'Select the correct translation from four options — race against the clock!'}
+        </p>
+      </header>
+
+      <div className="mode-tabs" role="tablist" aria-label="Game mode">
+        <button
+          role="tab"
+          aria-selected={gameMode === 'sense-sprint'}
+          className={`mode-tab ${gameMode === 'sense-sprint' ? 'mode-tab-active' : ''}`}
+          onClick={() => setGameMode('sense-sprint')}
+        >
+          Sense Sprint
+        </button>
+        <button
+          role="tab"
+          aria-selected={gameMode === 'translation-quiz'}
+          className={`mode-tab ${gameMode === 'translation-quiz' ? 'mode-tab-active' : ''}`}
+          onClick={() => setGameMode('translation-quiz')}
+        >
+          Translation Quiz
+        </button>
+      </div>
+
+      {gameMode === 'sense-sprint' ? <SenseSprint /> : <TranslationQuiz />}
     </main>
   )
 }

--- a/source/Demo/sense-sprint-web/src/App.tsx
+++ b/source/Demo/sense-sprint-web/src/App.tsx
@@ -3,6 +3,7 @@ import './App.css'
 
 type RoundStatus = 'in-progress' | 'won' | 'lost' | 'expired' | 'completed'
 type FeedbackTone = 'info' | 'success' | 'warning' | 'error'
+type CelebrationLevel = 'none' | 'win' | 'major'
 
 type RateLimitDebug = {
   limit: number
@@ -12,6 +13,7 @@ type RateLimitDebug = {
 
 type ActiveRound = {
   roundId: string
+  language: string
   clue: string
   clueIndex: number
   maxClues: number
@@ -23,6 +25,7 @@ type ActiveRound = {
 
 type CreateRoundResponse = {
   roundId: string
+  language: string
   expiresAtUtc: string
   clueIndex: number
   clue: string
@@ -61,14 +64,207 @@ type ApiResult<T> = {
   rateLimit: RateLimitDebug | null
 }
 
+type LanguagesResponse = {
+  language_names: Record<string, string>
+  resources: {
+    global?: {
+      source_languages?: string[]
+    }
+  }
+}
+
+type LanguageOption = {
+  code: string
+  name: string
+}
+
+type GameStats = {
+  currentScore: number
+  highScore: number
+  roundsStarted: number
+  roundsWon: number
+  roundsLost: number
+  roundsExpired: number
+  roundsGivenUp: number
+  roundsAbandoned: number
+  wordsGuessedCorrectly: number
+  cluesRequested: number
+  totalCluesSeen: number
+  totalGuessesSubmitted: number
+  currentStreak: number
+  highestStreak: number
+  majorCelebrations: number
+  lastPlayedAt: string | null
+}
+
+type StoredSession = {
+  round: ActiveRound
+  revealedClues: string[]
+  guess: string
+}
+
+const statsStorageKey = 'sense-sprint-stats-v1'
+const sessionStorageKey = 'sense-sprint-session-v1'
+
+const defaultStats: GameStats = {
+  currentScore: 0,
+  highScore: 0,
+  roundsStarted: 0,
+  roundsWon: 0,
+  roundsLost: 0,
+  roundsExpired: 0,
+  roundsGivenUp: 0,
+  roundsAbandoned: 0,
+  wordsGuessedCorrectly: 0,
+  cluesRequested: 0,
+  totalCluesSeen: 0,
+  totalGuessesSubmitted: 0,
+  currentStreak: 0,
+  highestStreak: 0,
+  majorCelebrations: 0,
+  lastPlayedAt: null,
+}
+
+function loadStats(): GameStats {
+  if (typeof window === 'undefined') {
+    return { ...defaultStats }
+  }
+
+  const raw = window.localStorage.getItem(statsStorageKey)
+  if (!raw) {
+    return { ...defaultStats }
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<GameStats>
+    return {
+      ...defaultStats,
+      ...parsed,
+      lastPlayedAt: typeof parsed.lastPlayedAt === 'string' ? parsed.lastPlayedAt : null,
+    }
+  } catch {
+    return { ...defaultStats }
+  }
+}
+
+function isValidStoredRound(value: unknown): value is ActiveRound {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+
+  const candidate = value as Partial<ActiveRound>
+
+  return (
+    typeof candidate.roundId === 'string' &&
+    typeof candidate.language === 'string' &&
+    typeof candidate.clue === 'string' &&
+    typeof candidate.clueIndex === 'number' &&
+    typeof candidate.maxClues === 'number' &&
+    typeof candidate.expiresAtUtc === 'string' &&
+    typeof candidate.scoreIfCorrect === 'number' &&
+    typeof candidate.roundStatus === 'string' &&
+    (typeof candidate.answer === 'string' || candidate.answer === null)
+  )
+}
+
+function loadStoredSession(): StoredSession | null {
+  if (typeof window === 'undefined') {
+    return null
+  }
+
+  const raw = window.localStorage.getItem(sessionStorageKey)
+  if (!raw) {
+    return null
+  }
+
+  try {
+    const parsed = JSON.parse(raw) as Partial<StoredSession>
+    if (!isValidStoredRound(parsed.round) || parsed.round.roundStatus !== 'in-progress') {
+      return null
+    }
+
+    return {
+      round: parsed.round,
+      revealedClues: Array.isArray(parsed.revealedClues)
+        ? parsed.revealedClues.filter((item): item is string => typeof item === 'string')
+        : [parsed.round.clue],
+      guess: typeof parsed.guess === 'string' ? parsed.guess : '',
+    }
+  } catch {
+    return null
+  }
+}
+
+function clearStoredSession(): void {
+  if (typeof window === 'undefined') {
+    return
+  }
+
+  window.localStorage.removeItem(sessionStorageKey)
+}
+
+function getSecondsRemaining(expiresAtUtc: string): number {
+  return Math.max(0, Math.floor((new Date(expiresAtUtc).getTime() - Date.now()) / 1000))
+}
+
+function getStreakMultiplier(streak: number): number {
+  if (streak >= 15) {
+    return 2
+  }
+
+  if (streak >= 10) {
+    return 1.65
+  }
+
+  if (streak >= 5) {
+    return 1.35
+  }
+
+  if (streak >= 3) {
+    return 1.15
+  }
+
+  return 1
+}
+
+function getAdjustedScore(baseScore: number, streak: number): number {
+  return Math.max(baseScore, Math.round(baseScore * getStreakMultiplier(streak)))
+}
+
+function getCelebrationLevel(streak: number): CelebrationLevel {
+  if (streak > 0 && streak % 5 === 0) {
+    return 'major'
+  }
+
+  if (streak > 0) {
+    return 'win'
+  }
+
+  return 'none'
+}
+
+function formatAverage(value: number): string {
+  if (!Number.isFinite(value)) {
+    return '0.0'
+  }
+
+  return value.toFixed(1)
+}
+
 const api = {
-  async createRound(): Promise<ApiResult<CreateRoundResponse>> {
+  async createRound(language: string): Promise<ApiResult<CreateRoundResponse>> {
     const response = await fetch('/game/sense-sprint/rounds', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ language }),
     })
 
     return parseResponse<CreateRoundResponse>(response)
+  },
+
+  async languages(): Promise<ApiResult<LanguagesResponse>> {
+    const response = await fetch('/languages')
+    return parseResponse<LanguagesResponse>(response)
   },
 
   async nextClue(roundId: string): Promise<ApiResult<NextClueResponse>> {
@@ -137,10 +333,12 @@ async function parseResponse<T>(response: Response): Promise<ApiResult<T>> {
 function App() {
   const [round, setRound] = useState<ActiveRound | null>(null)
   const [guess, setGuess] = useState('')
+  const [selectedLanguage, setSelectedLanguage] = useState('en')
+  const [languageOptions, setLanguageOptions] = useState<LanguageOption[]>([{ code: 'en', name: 'English' }])
+  const [loadingLanguages, setLoadingLanguages] = useState(true)
   const [statusMessage, setStatusMessage] = useState('Start a round to begin.')
   const [feedbackTone, setFeedbackTone] = useState<FeedbackTone>('info')
-  const [points, setPoints] = useState(0)
-  const [roundsPlayed, setRoundsPlayed] = useState(0)
+  const [stats, setStats] = useState<GameStats>(() => loadStats())
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
   const [timeLeft, setTimeLeft] = useState(0)
@@ -149,25 +347,215 @@ function App() {
   const [debugCallCount, setDebugCallCount] = useState(0)
   const [debugLastUpdated, setDebugLastUpdated] = useState('-')
   const [debugPulseTick, setDebugPulseTick] = useState(0)
+  const [hasHydratedSession, setHasHydratedSession] = useState(false)
+  const [statsOpen, setStatsOpen] = useState(() => {
+    if (typeof window === 'undefined') return true
+    return window.innerWidth >= 760
+  })
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    window.localStorage.setItem(statsStorageKey, JSON.stringify(stats))
+  }, [stats])
+
+  useEffect(() => {
+    let isCancelled = false
+
+    const loadLanguages = async () => {
+      setLoadingLanguages(true)
+      try {
+        const languageResult = await api.languages()
+        if (isCancelled) {
+          return
+        }
+
+        console.log('Languages response:', languageResult.data)
+        const languageNames = languageResult.data.language_names ?? {}
+        const sourceLanguages = languageResult.data.resources?.global?.source_languages ?? []
+        console.log('Parsed sourceLanguages:', sourceLanguages)
+        const options = sourceLanguages
+          .map((code) => code.trim().toLowerCase())
+          .filter((code, index, current) => code.length > 0 && current.indexOf(code) === index)
+          .map((code) => ({
+            code,
+            name: languageNames[code] ?? code.toUpperCase(),
+          }))
+          .sort((left, right) => left.name.localeCompare(right.name))
+
+        const safeOptions = options.length > 0 ? options : [{ code: 'en', name: 'English' }]
+        setLanguageOptions(safeOptions)
+        setSelectedLanguage((current) => {
+          if (safeOptions.some((option) => option.code === current)) {
+            return current
+          }
+
+          const englishFallback = safeOptions.find((option) => option.code === 'en')
+          return englishFallback?.code ?? safeOptions[0].code
+        })
+      } catch (err) {
+        console.error('Failed to load languages:', err)
+        if (!isCancelled) {
+          setLanguageOptions([{ code: 'en', name: 'English' }])
+          setSelectedLanguage('en')
+        }
+      } finally {
+        if (!isCancelled) {
+          setLoadingLanguages(false)
+        }
+      }
+    }
+
+    void loadLanguages()
+
+    return () => {
+      isCancelled = true
+    }
+  }, [])
+
+  useEffect(() => {
+    if (hasHydratedSession) {
+      return
+    }
+
+    setHasHydratedSession(true)
+    const storedSession = loadStoredSession()
+    if (!storedSession) {
+      return
+    }
+
+    if (getSecondsRemaining(storedSession.round.expiresAtUtc) <= 0) {
+      clearStoredSession()
+      setStats((current) => ({
+        ...current,
+        roundsExpired: current.roundsExpired + 1,
+        currentStreak: 0,
+        lastPlayedAt: new Date().toISOString(),
+      }))
+      setStatusMessage(
+        stats.currentStreak > 0
+          ? `Saved round expired while you were away. ${stats.currentStreak}-win streak reset.`
+          : 'Saved round expired while you were away. Start a new round.',
+      )
+      setFeedbackTone('warning')
+      return
+    }
+
+    setRound(storedSession.round)
+    setSelectedLanguage(storedSession.round.language)
+    setRevealedClues(storedSession.revealedClues.length > 0 ? storedSession.revealedClues : [storedSession.round.clue])
+    setGuess(storedSession.guess)
+    setTimeLeft(getSecondsRemaining(storedSession.round.expiresAtUtc))
+    setStatusMessage('Round restored. Pick up where you left off.')
+    setFeedbackTone('info')
+  }, [hasHydratedSession, stats.currentStreak])
+
+  useEffect(() => {
+    if (typeof window === 'undefined') {
+      return
+    }
+
+    if (!round || round.roundStatus !== 'in-progress') {
+      clearStoredSession()
+      return
+    }
+
+    const sessionPayload: StoredSession = {
+      round,
+      revealedClues: revealedClues.length > 0 ? revealedClues : [round.clue],
+      guess,
+    }
+
+    window.localStorage.setItem(sessionStorageKey, JSON.stringify(sessionPayload))
+  }, [round, revealedClues, guess])
 
   useEffect(() => {
     if (!round || round.roundStatus !== 'in-progress') {
       return
     }
 
-    const timer = window.setInterval(() => {
-      const expires = new Date(round.expiresAtUtc).getTime()
-      const diff = Math.max(0, Math.floor((expires - Date.now()) / 1000))
+    const tick = () => {
+      const diff = getSecondsRemaining(round.expiresAtUtc)
       setTimeLeft(diff)
+
+      if (diff > 0) {
+        return
+      }
+
+      // Auto-giveup when timer expires to reveal answer
+      setLoading(true)
+      api
+        .giveUp(round.roundId)
+        .then((result) => {
+          const streakBeforeExpiry = stats.currentStreak
+
+          setRound((current) => {
+            if (!current || current.roundId !== round.roundId) {
+              return current
+            }
+
+            return {
+              ...current,
+              roundStatus: 'expired',
+              answer: result.data.correctAnswer,
+            }
+          })
+
+          setStats((current) => ({
+            ...current,
+            roundsExpired: current.roundsExpired + 1,
+            currentStreak: 0,
+            lastPlayedAt: new Date().toISOString(),
+          }))
+
+          setStatusMessage(
+            streakBeforeExpiry > 0
+              ? `Time expired. ${streakBeforeExpiry}-win streak reset.`
+              : 'Time expired. Start a new round.',
+          )
+          setFeedbackTone('warning')
+          setGuess('')
+          clearStoredSession()
+        })
+        .catch((err) => {
+          console.error('Failed to process round expiry:', err)
+          setError(String(err))
+          setStatusMessage('Round ended but could not retrieve answer.')
+          setFeedbackTone('error')
+        })
+        .finally(() => {
+          setLoading(false)
+        })
+    }
+
+    tick()
+    const timer = window.setInterval(() => {
+      tick()
     }, 250)
 
     return () => window.clearInterval(timer)
-  }, [round])
+  }, [round, stats.currentStreak])
 
   const canInteract = useMemo(
     () => Boolean(round && round.roundStatus === 'in-progress' && !loading),
     [round, loading],
   )
+
+  const streakMultiplier = useMemo(() => getStreakMultiplier(stats.currentStreak), [stats.currentStreak])
+  const scoreIfCorrect = useMemo(
+    () => (round ? getAdjustedScore(round.scoreIfCorrect, stats.currentStreak) : 0),
+    [round, stats.currentStreak],
+  )
+  const clueStep = round ? `${round.clueIndex + 1}/${round.maxClues}` : '0/0'
+  const usedRequests = rateLimitDebug ? Math.max(0, rateLimitDebug.limit - rateLimitDebug.limitRemaining) : null
+  const celebrationLevel = round?.roundStatus === 'won' ? getCelebrationLevel(stats.currentStreak) : 'none'
+  const averageCluesPerRound = stats.roundsStarted > 0 ? stats.totalCluesSeen / stats.roundsStarted : 0
+  const averageRequestedCluesPerRound = stats.roundsStarted > 0 ? stats.cluesRequested / stats.roundsStarted : 0
+  const nextCelebrationAt = Math.floor(stats.currentStreak / 5) * 5 + 5
+  const winsUntilCelebration = nextCelebrationAt - stats.currentStreak
+  const selectedLanguageName = languageOptions.find((option) => option.code === selectedLanguage)?.name ?? selectedLanguage.toUpperCase()
 
   function refreshDebug(rateLimit: RateLimitDebug | null): void {
     setDebugCallCount((current) => current + 1)
@@ -179,14 +567,30 @@ function App() {
   }
 
   async function startRound(): Promise<void> {
+    const isAbandoningActiveRound = round?.roundStatus === 'in-progress'
+    const streakBeforeReset = stats.currentStreak
+
+    if (isAbandoningActiveRound) {
+      const confirmed = window.confirm(
+        streakBeforeReset > 0
+          ? `Starting a new word will reset your ${streakBeforeReset}-win streak. Continue?`
+          : 'Starting a new word will abandon the current round. Continue?',
+      )
+
+      if (!confirmed) {
+        return
+      }
+    }
+
     setLoading(true)
     setError('')
 
     try {
-      const createdResult = await api.createRound()
+      const createdResult = await api.createRound(selectedLanguage)
       const created = createdResult.data
       setRound({
         roundId: created.roundId,
+        language: created.language,
         clue: created.clue,
         clueIndex: created.clueIndex,
         maxClues: created.maxClues,
@@ -195,13 +599,30 @@ function App() {
         roundStatus: 'in-progress',
         answer: null,
       })
+      setSelectedLanguage(created.language)
       setRevealedClues([created.clue])
+      setTimeLeft(getSecondsRemaining(created.expiresAtUtc))
       refreshDebug(createdResult.rateLimit ?? created.rateLimit)
 
-      setRoundsPlayed((current) => current + 1)
+      setStats((current) => ({
+        ...current,
+        roundsStarted: current.roundsStarted + 1,
+        roundsAbandoned: current.roundsAbandoned + (isAbandoningActiveRound ? 1 : 0),
+        currentStreak: isAbandoningActiveRound ? 0 : current.currentStreak,
+        totalCluesSeen: current.totalCluesSeen + 1,
+        lastPlayedAt: new Date().toISOString(),
+      }))
       setGuess('')
-      setStatusMessage('Round started. Read the clue and submit your best guess.')
-      setFeedbackTone('info')
+      if (isAbandoningActiveRound && streakBeforeReset > 0) {
+        setStatusMessage(`New round started. ${streakBeforeReset}-win streak reset.`)
+        setFeedbackTone('warning')
+      } else if (isAbandoningActiveRound) {
+        setStatusMessage('New round started. Previous word skipped.')
+        setFeedbackTone('warning')
+      } else {
+        setStatusMessage('Round started. Read the clue and submit your best guess.')
+        setFeedbackTone('info')
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Unable to start round.'
       setError(message)
@@ -243,6 +664,13 @@ function App() {
         return [...current, next.clue]
       })
       refreshDebug(nextResult.rateLimit)
+      setTimeLeft(getSecondsRemaining(next.expiresAtUtc))
+      setStats((current) => ({
+        ...current,
+        cluesRequested: current.cluesRequested + 1,
+        totalCluesSeen: current.totalCluesSeen + 1,
+        lastPlayedAt: new Date().toISOString(),
+      }))
       setStatusMessage('New clue revealed.')
       setFeedbackTone('info')
     } catch (err) {
@@ -259,14 +687,43 @@ function App() {
       return
     }
 
+    const streakBeforeGuess = stats.currentStreak
+
     setLoading(true)
     setError('')
 
     try {
       const guessResult = await api.guess(round.roundId, guess)
       const result = guessResult.data
+
+      setStats((current) => ({
+        ...current,
+        totalGuessesSubmitted: current.totalGuessesSubmitted + 1,
+        lastPlayedAt: new Date().toISOString(),
+      }))
+
       if (result.isCorrect) {
-        setPoints((current) => current + result.awardedPoints)
+        const awardedPoints = getAdjustedScore(result.awardedPoints, streakBeforeGuess)
+        const nextStreak = streakBeforeGuess + 1
+
+        setStats((current) => ({
+          ...current,
+          currentScore: current.currentScore + awardedPoints,
+          highScore: Math.max(current.highScore, awardedPoints),
+          roundsWon: current.roundsWon + 1,
+          wordsGuessedCorrectly: current.wordsGuessedCorrectly + 1,
+          currentStreak: nextStreak,
+          highestStreak: Math.max(current.highestStreak, nextStreak),
+          majorCelebrations: current.majorCelebrations + (nextStreak % 5 === 0 ? 1 : 0),
+          lastPlayedAt: new Date().toISOString(),
+        }))
+
+        setStatusMessage(
+          nextStreak % 5 === 0
+            ? `Correct! +${awardedPoints} points. ${nextStreak}-win streak. Major celebration unlocked.`
+            : `Correct! +${awardedPoints} points. Streak is now ${nextStreak}.`,
+        )
+        setFeedbackTone('success')
       }
 
       setRound((current) => {
@@ -282,16 +739,31 @@ function App() {
       })
       refreshDebug(guessResult.rateLimit)
 
-      if (result.roundStatus === 'won') {
-        setStatusMessage(`Correct! +${result.awardedPoints} points.`)
-        setFeedbackTone('success')
-      } else if (result.roundStatus === 'lost') {
-        setStatusMessage(`No more clues. Answer: ${result.correctAnswer ?? 'unknown'}`)
+      if (result.roundStatus === 'lost') {
+        setStats((current) => ({
+          ...current,
+          roundsLost: current.roundsLost + 1,
+          currentStreak: 0,
+          lastPlayedAt: new Date().toISOString(),
+        }))
+        setStatusMessage(
+          streakBeforeGuess > 0
+            ? `No more clues. Answer: ${result.correctAnswer ?? 'unknown'}. ${streakBeforeGuess}-win streak reset.`
+            : `No more clues. Answer: ${result.correctAnswer ?? 'unknown'}`,
+        )
         setFeedbackTone('warning')
       } else if (result.roundStatus === 'expired') {
-        setStatusMessage('Round expired. Start a new round.')
+        setStats((current) => ({
+          ...current,
+          roundsExpired: current.roundsExpired + 1,
+          currentStreak: 0,
+          lastPlayedAt: new Date().toISOString(),
+        }))
+        setStatusMessage(
+          streakBeforeGuess > 0 ? `Round expired. ${streakBeforeGuess}-win streak reset.` : 'Round expired. Start a new round.',
+        )
         setFeedbackTone('warning')
-      } else {
+      } else if (result.roundStatus !== 'won') {
         setStatusMessage('Not correct yet. Ask for the next clue or try again.')
         setFeedbackTone('info')
       }
@@ -310,6 +782,8 @@ function App() {
     if (!round) {
       return
     }
+
+    const streakBeforeGiveUp = stats.currentStreak
 
     setLoading(true)
     setError('')
@@ -330,7 +804,18 @@ function App() {
       })
       refreshDebug(giveUpResult.rateLimit)
 
-      setStatusMessage(`You gave up. Answer: ${result.correctAnswer ?? 'unknown'}`)
+      setStats((current) => ({
+        ...current,
+        roundsGivenUp: current.roundsGivenUp + 1,
+        currentStreak: 0,
+        lastPlayedAt: new Date().toISOString(),
+      }))
+
+      setStatusMessage(
+        streakBeforeGiveUp > 0
+          ? `You gave up. Answer: ${result.correctAnswer ?? 'unknown'}. ${streakBeforeGiveUp}-win streak reset.`
+          : `You gave up. Answer: ${result.correctAnswer ?? 'unknown'}`,
+      )
       setFeedbackTone('warning')
       setGuess('')
     } catch (err) {
@@ -342,9 +827,30 @@ function App() {
     }
   }
 
-  const scoreIfCorrect = round?.scoreIfCorrect ?? 0
-  const clueStep = round ? `${round.clueIndex + 1}/${round.maxClues}` : '0/0'
-  const usedRequests = rateLimitDebug ? Math.max(0, rateLimitDebug.limit - rateLimitDebug.limitRemaining) : null
+  function resetStats(): void {
+    const hasActiveRound = round?.roundStatus === 'in-progress'
+    const confirmed = window.confirm(
+      hasActiveRound
+        ? 'Reset all saved stats? This clears score, streak, and high score, but keeps the current word active.'
+        : 'Reset all saved stats, including score, streak, and high score?',
+    )
+
+    if (!confirmed) {
+      return
+    }
+
+    if (typeof window !== 'undefined') {
+      window.localStorage.removeItem(statsStorageKey)
+    }
+
+    setStats({
+      ...defaultStats,
+      lastPlayedAt: new Date().toISOString(),
+    })
+    setStatusMessage(hasActiveRound ? 'Lifetime stats reset. Current round preserved.' : 'Lifetime stats reset.')
+    setFeedbackTone('warning')
+    setError('')
+  }
 
   return (
     <main className="page">
@@ -357,20 +863,62 @@ function App() {
       </header>
 
       <section className="panel grid">
-        <div className="stats">
+        <details open={statsOpen} onToggle={(e) => setStatsOpen(e.currentTarget.open)} className="stats-collapsible">
+          <summary className="stats-summary">Performance Snapshot</summary>
+          <div className="stats">
           <article className="kpi">
             <p className="kpi-label">Total Points</p>
-            <p className="kpi-value">{points}</p>
+            <p className="kpi-value">{stats.currentScore}</p>
           </article>
           <article className="kpi">
-            <p className="kpi-label">Rounds Played</p>
-            <p className="kpi-value">{roundsPlayed}</p>
+            <p className="kpi-label">High Score</p>
+            <p className="kpi-value">{stats.highScore}</p>
+          </article>
+          <article className="kpi">
+            <p className="kpi-label">Win Streak</p>
+            <p className="kpi-value">{stats.currentStreak}</p>
+          </article>
+          <article className="kpi">
+            <p className="kpi-label">Highest Streak</p>
+            <p className="kpi-value">{stats.highestStreak}</p>
+          </article>
+          <article className="kpi">
+            <p className="kpi-label">Games Played</p>
+            <p className="kpi-value">{stats.roundsStarted}</p>
           </article>
           <article className="kpi">
             <p className="kpi-label">Time Left</p>
             <p className="kpi-value">{round ? `${timeLeft}s` : '-'}</p>
           </article>
         </div>
+
+        <section className={`streak-panel streak-panel-${celebrationLevel}`} aria-live="polite">
+          <div>
+            <p className="streak-label">Streak Bonus</p>
+            <p className="streak-value">{streakMultiplier.toFixed(2)}x scoring</p>
+            <p className="streak-copy">
+              Bonus plan: 3 wins unlock 1.15x, 5 wins unlock 1.35x and a major celebration, 10 wins reach 1.65x, and 15 wins push to 2.00x.
+            </p>
+            <p className="streak-copy">The current round is also saved locally, so a reload resumes the active word and revealed clues.</p>
+          </div>
+          <div className="streak-meta">
+            <p>
+              <strong>Next celebration:</strong> {winsUntilCelebration} win{winsUntilCelebration === 1 ? '' : 's'} away
+            </p>
+            <p>
+              <strong>Major celebrations:</strong> {stats.majorCelebrations}
+            </p>
+            <p>
+              <strong>Last played:</strong> {stats.lastPlayedAt ? new Date(stats.lastPlayedAt).toLocaleString() : 'Not yet'}
+            </p>
+          </div>
+        </section>
+        <div className="meta-actions">
+          <button className="button button-reset" onClick={resetStats} disabled={loading}>
+            Reset Stats
+          </button>
+        </div>
+        </details>
 
         <div className="clue">
           <p className="clue-label">Clue {clueStep}</p>
@@ -393,6 +941,23 @@ function App() {
         </div>
 
         <div className="controls">
+          <label className="language-picker" htmlFor="language-select">
+            <span>Round Language</span>
+            <select
+              id="language-select"
+              className="input"
+              value={selectedLanguage}
+              onChange={(event) => setSelectedLanguage(event.target.value)}
+              disabled={loading || loadingLanguages || round?.roundStatus === 'in-progress'}
+            >
+              {languageOptions.map((option) => (
+                <option key={option.code} value={option.code}>
+                  {option.name} ({option.code})
+                </option>
+              ))}
+            </select>
+          </label>
+
           <input
             className="input"
             placeholder="Type your guess"
@@ -426,12 +991,64 @@ function App() {
           </div>
         </div>
 
-        <p className={`status status-${feedbackTone} ${round?.roundStatus === 'won' ? 'status-win' : ''}`} role="status" aria-live="polite">
+        <p
+          className={`status status-${feedbackTone} ${round?.roundStatus === 'won' ? 'status-win' : ''} ${celebrationLevel === 'major' ? 'status-major-win' : ''}`}
+          role="status"
+          aria-live="polite"
+        >
           <strong>Status:</strong> {statusMessage}
         </p>
-        {round?.roundStatus === 'won' ? <p className="victory-banner">Word cracked. Keep the streak going!</p> : null}
+        {round?.roundStatus === 'won' ? (
+          <p className={`victory-banner ${celebrationLevel === 'major' ? 'victory-banner-major' : ''}`}>
+            {celebrationLevel === 'major'
+              ? `Word cracked. ${stats.currentStreak}-win streak. Fire the confetti cannons.`
+              : 'Word cracked. Keep the streak going!'}
+          </p>
+        ) : null}
         {error ? <p className="error">{error}</p> : null}
-        <p className="footer">Points available now: {scoreIfCorrect}</p>
+        <details className="metrics-collapsible">
+          <summary className="metrics-summary">Lifetime Statistics</summary>
+          <section className="metrics-grid" aria-label="Lifetime statistics">
+          <article className="metric-card">
+            <p className="metric-label">Words Guessed</p>
+            <p className="metric-value">{stats.wordsGuessedCorrectly}</p>
+          </article>
+          <article className="metric-card">
+            <p className="metric-label">Wins / Losses</p>
+            <p className="metric-value">{stats.roundsWon} / {stats.roundsLost}</p>
+          </article>
+          <article className="metric-card">
+            <p className="metric-label">Expired / Give Ups</p>
+            <p className="metric-value">{stats.roundsExpired} / {stats.roundsGivenUp}</p>
+          </article>
+          <article className="metric-card">
+            <p className="metric-label">Abandoned Rounds</p>
+            <p className="metric-value">{stats.roundsAbandoned}</p>
+          </article>
+          <article className="metric-card">
+            <p className="metric-label">Clues Requested</p>
+            <p className="metric-value">{stats.cluesRequested}</p>
+          </article>
+          <article className="metric-card">
+            <p className="metric-label">Guesses Submitted</p>
+            <p className="metric-value">{stats.totalGuessesSubmitted}</p>
+          </article>
+          <article className="metric-card">
+            <p className="metric-label">Avg. Clues / Round</p>
+            <p className="metric-value">{formatAverage(averageCluesPerRound)}</p>
+          </article>
+          <article className="metric-card">
+            <p className="metric-label">Avg. Extra Clues / Round</p>
+            <p className="metric-value">{formatAverage(averageRequestedCluesPerRound)}</p>
+          </article>
+        </section>
+        </details>
+        <p className="footer">
+          Active language: {round?.language?.toUpperCase() ?? selectedLanguageName}.
+          {' '}
+          Points available now: {scoreIfCorrect}
+          {round ? ` (${round.scoreIfCorrect} base x ${streakMultiplier.toFixed(2)} streak bonus)` : ''}
+        </p>
 
         <details className={`debug-panel ${debugPulseTick % 2 === 0 ? 'debug-panel-pulse-a' : 'debug-panel-pulse-b'}`}>
           <summary>Debug Info</summary>

--- a/source/Demo/sense-sprint-web/tests/e2e/mocks.ts
+++ b/source/Demo/sense-sprint-web/tests/e2e/mocks.ts
@@ -1,0 +1,72 @@
+/**
+ * Shared mock responses used by the E2E tests so that all tests run without a
+ * live Lexicala backend.  Every route intercept is set up via Playwright's
+ * `page.route()` API before the page is loaded.
+ */
+
+export const mockLanguagesResponse = {
+  language_names: {
+    en: 'English',
+    de: 'German',
+    nl: 'Dutch',
+    fr: 'French',
+    es: 'Spanish',
+    ja: 'Japanese',
+  },
+  resources: {
+    global: {
+      source_languages: ['en', 'de', 'nl', 'fr', 'es', 'ja'],
+      target_languages: ['de', 'nl', 'fr', 'es', 'ja'],
+    },
+  },
+}
+
+export const mockSenseSprintRound = {
+  roundId: 'aaaaaaaa-1111-1111-1111-aaaaaaaaaaaa',
+  language: 'en',
+  expiresAtUtc: new Date(Date.now() + 60_000).toISOString(),
+  clueIndex: 0,
+  clue: 'a building for human habitation',
+  scoreIfCorrect: 10,
+  maxClues: 5,
+  roundSeconds: 60,
+  rateLimit: null,
+}
+
+export const mockQuizRound = {
+  roundId: 'bbbbbbbb-2222-2222-2222-bbbbbbbbbbbb',
+  sourceWord: 'house',
+  sourceLanguage: 'en',
+  targetLanguage: 'de',
+  choices: ['Haus', 'Auto', 'Baum', 'Buch'],
+  expiresAtUtc: new Date(Date.now() + 30_000).toISOString(),
+  roundSeconds: 30,
+  rateLimit: null,
+}
+
+export const mockQuizCorrectAnswer = {
+  roundId: 'bbbbbbbb-2222-2222-2222-bbbbbbbbbbbb',
+  isCorrect: true,
+  roundStatus: 'won',
+  awardedPoints: 1,
+  correctAnswer: 'Haus',
+  message: 'Correct!',
+}
+
+export const mockQuizWrongAnswer = {
+  roundId: 'bbbbbbbb-2222-2222-2222-bbbbbbbbbbbb',
+  isCorrect: false,
+  roundStatus: 'lost',
+  awardedPoints: 0,
+  correctAnswer: 'Haus',
+  message: 'Incorrect. The correct translation was: Haus',
+}
+
+export const mockQuizExpired = {
+  roundId: 'bbbbbbbb-2222-2222-2222-bbbbbbbbbbbb',
+  isCorrect: false,
+  roundStatus: 'expired',
+  awardedPoints: 0,
+  correctAnswer: 'Haus',
+  message: "Time's up!",
+}

--- a/source/Demo/sense-sprint-web/tests/e2e/sense-sprint.spec.ts
+++ b/source/Demo/sense-sprint-web/tests/e2e/sense-sprint.spec.ts
@@ -1,0 +1,221 @@
+import { test, expect, Page } from '@playwright/test'
+import { mockLanguagesResponse } from './mocks'
+
+const firstSenseSprintRound = {
+  roundId: 'aaaaaaaa-1111-1111-1111-aaaaaaaaaaaa',
+  language: 'en',
+  expiresAtUtc: new Date(Date.now() + 60_000).toISOString(),
+  clueIndex: 0,
+  clue: 'a building for human habitation',
+  scoreIfCorrect: 4,
+  maxClues: 4,
+  roundSeconds: 60,
+  rateLimit: null,
+}
+
+const secondSenseSprintRoundWithoutLanguage = {
+  roundId: 'cccccccc-3333-3333-3333-cccccccccccc',
+  expiresAtUtc: new Date(Date.now() + 60_000).toISOString(),
+  clueIndex: 0,
+  clue: 'a small domesticated carnivorous mammal',
+  scoreIfCorrect: 4,
+  maxClues: 4,
+  roundSeconds: 60,
+  rateLimit: null,
+}
+
+const wonGuessResponse = {
+  roundId: firstSenseSprintRound.roundId,
+  isCorrect: true,
+  roundStatus: 'won',
+  awardedPoints: 4,
+  currentClueIndex: 0,
+  correctAnswer: 'house',
+  message: 'Correct!',
+}
+
+async function setupLanguagesMock(page: Page) {
+  await page.route('/languages', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockLanguagesResponse) }),
+  )
+}
+
+test.describe('Sense Sprint — round lifecycle', () => {
+  test('shows wrong answers entered after incorrect guesses', async ({ page }) => {
+    await setupLanguagesMock(page)
+
+    await page.route('/game/sense-sprint/rounds', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(firstSenseSprintRound),
+      })
+    })
+
+    await page.route(/\/game\/sense-sprint\/rounds\/.*\/guess/, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          roundId: firstSenseSprintRound.roundId,
+          isCorrect: false,
+          roundStatus: 'in-progress',
+          awardedPoints: 0,
+          currentClueIndex: 0,
+          correctAnswer: null,
+          message: 'Not quite',
+        }),
+      })
+    })
+
+    await page.goto('/')
+
+    await page.getByRole('button', { name: /Start Round/i }).click()
+    await page.getByPlaceholder('Type your guess').fill('castle')
+    await page.getByRole('button', { name: /Submit Guess/i }).click()
+
+    await expect(page.locator('[role="status"]')).toContainText(/Not correct yet/i)
+    await expect(page.locator('.wrong-history-list li')).toHaveCount(1)
+    await expect(page.locator('.wrong-history-list')).toContainText('castle')
+  })
+
+  test('starting a new round after a win does not blank the screen when language is missing in the response', async ({ page }) => {
+    const pageErrors: Error[] = []
+    page.on('pageerror', (error) => {
+      pageErrors.push(error)
+    })
+
+    await setupLanguagesMock(page)
+
+    let createRoundCallCount = 0
+    await page.route('/game/sense-sprint/rounds', async (route) => {
+      createRoundCallCount += 1
+      const payload = createRoundCallCount === 1 ? firstSenseSprintRound : secondSenseSprintRoundWithoutLanguage
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(payload),
+      })
+    })
+
+    await page.route(/\/game\/sense-sprint\/rounds\/.*\/guess/, async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify(wonGuessResponse),
+      })
+    })
+
+    await page.goto('/')
+
+    await page.getByRole('button', { name: /Start Round/i }).click()
+    await expect(page.locator('.clue-text')).toHaveText(firstSenseSprintRound.clue)
+
+    await page.getByPlaceholder('Type your guess').fill('house')
+    await page.getByRole('button', { name: /Submit Guess/i }).click()
+    await expect(page.locator('[role="status"]')).toContainText(/Correct!/i)
+
+    await page.getByRole('button', { name: /New Round/i }).click()
+
+    await expect(page.locator('.clue-text')).toHaveText(secondSenseSprintRoundWithoutLanguage.clue)
+    await expect(page.locator('[role="status"]')).toContainText(/Round started/i)
+    await expect(page.locator('.footer')).toContainText(/Active language: EN/i)
+    await expect(pageErrors).toHaveLength(0)
+  })
+
+  test('uses the selected language when creating a new round', async ({ page }) => {
+    await setupLanguagesMock(page)
+
+    await page.addInitScript(() => {
+      window.localStorage.removeItem('sense-sprint-session-v1')
+      window.localStorage.removeItem('sense-sprint-stats-v1')
+    })
+
+    let requestedLanguage: string | undefined
+    await page.route('/game/sense-sprint/rounds', async (route) => {
+      const postData = route.request().postDataJSON() as { language?: string } | null
+      requestedLanguage = postData?.language
+
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          roundId: 'dddddddd-4444-4444-4444-dddddddddddd',
+          language: 'de',
+          expiresAtUtc: new Date(Date.now() + 60_000).toISOString(),
+          clueIndex: 0,
+          clue: 'ein Gebaude zum Wohnen',
+          scoreIfCorrect: 4,
+          maxClues: 4,
+          roundSeconds: 60,
+          rateLimit: null,
+        }),
+      })
+    })
+
+    await page.goto('/')
+
+    await page.locator('#language-select').selectOption('de')
+    await page.getByRole('button', { name: /Start Round/i }).click()
+
+    expect(requestedLanguage).toBe('de')
+    await expect(page.locator('.clue-text')).toHaveText('ein Gebaude zum Wohnen')
+    await expect(page.locator('.footer')).toContainText(/Active language: DE/i)
+  })
+
+  test('timer expiry with round-not-found response is handled once without repeated give-up calls', async ({ page }) => {
+    const pageErrors: Error[] = []
+    page.on('pageerror', (error) => {
+      pageErrors.push(error)
+    })
+
+    await setupLanguagesMock(page)
+
+    await page.addInitScript(() => {
+      window.localStorage.removeItem('sense-sprint-session-v1')
+      window.localStorage.removeItem('sense-sprint-stats-v1')
+    })
+
+    await page.route('/game/sense-sprint/rounds', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          roundId: 'eeeeeeee-5555-5555-5555-eeeeeeeeeeee',
+          language: 'en',
+          expiresAtUtc: new Date(Date.now() + 1_000).toISOString(),
+          clueIndex: 0,
+          clue: 'a period of sixty seconds',
+          scoreIfCorrect: 4,
+          maxClues: 4,
+          roundSeconds: 1,
+          rateLimit: null,
+        }),
+      })
+    })
+
+    let giveUpCallCount = 0
+    await page.route(/\/game\/sense-sprint\/rounds\/.*\/give-up/, async (route) => {
+      giveUpCallCount += 1
+      await route.fulfill({
+        status: 404,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          title: 'Round not found',
+          detail: 'Round not found. Start a new round.',
+        }),
+      })
+    })
+
+    await page.goto('/')
+
+    await page.getByRole('button', { name: /Start Round/i }).click()
+    await expect(page.locator('.clue-text')).toHaveText('a period of sixty seconds')
+
+    await expect(page.locator('[role="status"]')).toContainText(/Time expired/i, { timeout: 8_000 })
+    await page.waitForTimeout(1_500)
+
+    expect(giveUpCallCount).toBe(1)
+    await expect(pageErrors).toHaveLength(0)
+  })
+})

--- a/source/Demo/sense-sprint-web/tests/e2e/translation-quiz.spec.ts
+++ b/source/Demo/sense-sprint-web/tests/e2e/translation-quiz.spec.ts
@@ -1,0 +1,234 @@
+import { test, expect, Page } from '@playwright/test'
+import {
+  mockLanguagesResponse,
+  mockQuizRound,
+  mockQuizCorrectAnswer,
+  mockQuizWrongAnswer,
+  mockQuizExpired,
+} from './mocks'
+
+// ─── helpers ─────────────────────────────────────────────────────────────────
+
+async function setupLanguagesMock(page: Page) {
+  await page.route('/languages', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockLanguagesResponse) }),
+  )
+}
+
+async function setupQuizRoundMock(page: Page) {
+  await page.route('/game/translation-quiz/rounds', (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(mockQuizRound) }),
+  )
+}
+
+async function setupAnswerMock(page: Page, response: object) {
+  await page.route(/\/game\/translation-quiz\/rounds\/.*\/answer/, (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(response) }),
+  )
+}
+
+async function setupExpireMock(page: Page, response: object) {
+  await page.route(/\/game\/translation-quiz\/rounds\/.*\/expire/, (route) =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify(response) }),
+  )
+}
+
+async function openTranslationQuizTab(page: Page) {
+  await page.getByRole('tab', { name: 'Translation Quiz' }).click()
+}
+
+// ─── tests ────────────────────────────────────────────────────────────────────
+
+test.describe('Translation Quiz — language dropdown', () => {
+  test('shows "Random (any language)" as first option', async ({ page }) => {
+    await setupLanguagesMock(page)
+    await page.goto('/')
+
+    await openTranslationQuizTab(page)
+
+    const select = page.locator('#quiz-target-language')
+    await expect(select).toBeVisible()
+
+    // First option should be the random placeholder with empty value
+    const firstOption = select.locator('option').first()
+    await expect(firstOption).toHaveText(/Random/i)
+    await expect(firstOption).toHaveAttribute('value', '')
+  })
+
+  test('populates dropdown with languages from the API', async ({ page }) => {
+    await setupLanguagesMock(page)
+    await page.goto('/')
+
+    await openTranslationQuizTab(page)
+
+    // All five API target languages should appear in the dropdown
+    const select = page.locator('#quiz-target-language')
+    for (const [code, name] of [['de', 'German'], ['nl', 'Dutch'], ['fr', 'French'], ['es', 'Spanish'], ['ja', 'Japanese']]) {
+      const option = select.locator(`option[value="${code}"]`)
+      await expect(option).toHaveText(new RegExp(name, 'i'))
+    }
+  })
+
+  test('falls back gracefully when languages API fails', async ({ page }) => {
+    await page.route('/languages', (route) => route.fulfill({ status: 500 }))
+    await page.goto('/')
+
+    await openTranslationQuizTab(page)
+
+    // Dropdown still visible with at least the random option
+    const select = page.locator('#quiz-target-language')
+    await expect(select).toBeVisible()
+    await expect(select.locator('option').first()).toHaveText(/Random/i)
+  })
+})
+
+test.describe('Translation Quiz — round lifecycle', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupLanguagesMock(page)
+    await setupQuizRoundMock(page)
+  })
+
+  test('starts a round and shows the source word and four choices', async ({ page }) => {
+    await page.goto('/')
+    await openTranslationQuizTab(page)
+
+    await page.getByRole('button', { name: /Start Round/i }).click()
+
+    await expect(page.getByText('house')).toBeVisible()
+
+    const choices = page.locator('.quiz-choice')
+    await expect(choices).toHaveCount(4)
+    for (const choice of ['Haus', 'Auto', 'Baum', 'Buch']) {
+      await expect(page.getByRole('button', { name: choice })).toBeVisible()
+    }
+  })
+
+  test('shows the target language name in the quiz prompt', async ({ page }) => {
+    await page.goto('/')
+    await openTranslationQuizTab(page)
+
+    await page.getByRole('button', { name: /Start Round/i }).click()
+
+    // "de" → "German" is resolved from the language names in the languages API
+    await expect(page.locator('.quiz-word-label')).toContainText(/German/i)
+  })
+
+  test('correct choice highlights green and shows won status', async ({ page }) => {
+    await setupAnswerMock(page, mockQuizCorrectAnswer)
+    await page.goto('/')
+    await openTranslationQuizTab(page)
+
+    await page.getByRole('button', { name: /Start Round/i }).click()
+    await page.getByRole('button', { name: 'Haus' }).click()
+
+    await expect(page.getByRole('button', { name: 'Haus' })).toHaveClass(/quiz-choice-correct/)
+    await expect(page.locator('[role="status"]')).toContainText(/Correct/i)
+  })
+
+  test('wrong choice highlights red and shows the correct answer', async ({ page }) => {
+    await setupAnswerMock(page, mockQuizWrongAnswer)
+    await page.goto('/')
+    await openTranslationQuizTab(page)
+
+    await page.getByRole('button', { name: /Start Round/i }).click()
+    await page.getByRole('button', { name: 'Auto' }).click()
+
+    await expect(page.getByRole('button', { name: 'Auto' })).toHaveClass(/quiz-choice-wrong/)
+    await expect(page.getByRole('button', { name: 'Haus' })).toHaveClass(/quiz-choice-correct/)
+    await expect(page.locator('[role="status"]')).toContainText(/Haus/i)
+  })
+
+  test('choices are disabled after an answer is submitted', async ({ page }) => {
+    await setupAnswerMock(page, mockQuizCorrectAnswer)
+    await page.goto('/')
+    await openTranslationQuizTab(page)
+
+    await page.getByRole('button', { name: /Start Round/i }).click()
+    await page.getByRole('button', { name: 'Haus' }).click()
+
+    for (const choice of ['Haus', 'Auto', 'Baum', 'Buch']) {
+      await expect(page.getByRole('button', { name: choice })).toBeDisabled()
+    }
+  })
+
+  test('"New Round" button appears after completing a round', async ({ page }) => {
+    await setupAnswerMock(page, mockQuizCorrectAnswer)
+    await page.goto('/')
+    await openTranslationQuizTab(page)
+
+    await page.getByRole('button', { name: /Start Round/i }).click()
+    await page.getByRole('button', { name: 'Haus' }).click()
+
+    await expect(page.getByRole('button', { name: /New Round/i })).toBeVisible()
+  })
+})
+
+test.describe('Translation Quiz — stats', () => {
+  test.beforeEach(async ({ page }) => {
+    await setupLanguagesMock(page)
+    await setupQuizRoundMock(page)
+    // Clear any persisted quiz stats from prior test runs
+    await page.addInitScript(() => {
+      window.localStorage.removeItem('translation-quiz-stats-v1')
+    })
+  })
+
+  test('win streak increments on correct answer', async ({ page }) => {
+    await setupAnswerMock(page, mockQuizCorrectAnswer)
+    await page.goto('/')
+    await openTranslationQuizTab(page)
+
+    await page.getByRole('button', { name: /Start Round/i }).click()
+    await page.getByRole('button', { name: 'Haus' }).click()
+
+    await expect(page.getByText('1').first()).toBeVisible()
+    await expect(page.locator('.kpi', { hasText: /Win Streak/i })).toContainText('1')
+  })
+
+  test('win streak resets to 0 on wrong answer', async ({ page }) => {
+    await setupAnswerMock(page, mockQuizWrongAnswer)
+    await page.goto('/')
+    await openTranslationQuizTab(page)
+
+    await page.getByRole('button', { name: /Start Round/i }).click()
+    await page.getByRole('button', { name: 'Auto' }).click()
+
+    await expect(page.locator('.kpi', { hasText: /Win Streak/i })).toContainText('0')
+  })
+
+  test('rounds played counter increments on new round', async ({ page }) => {
+    await page.goto('/')
+    await openTranslationQuizTab(page)
+
+    await expect(page.locator('.kpi', { hasText: /Rounds/i })).toContainText('0')
+    await page.getByRole('button', { name: /Start Round/i }).click()
+    await expect(page.locator('.kpi', { hasText: /Rounds/i })).toContainText('1')
+  })
+})
+
+test.describe('Translation Quiz — timer expiry', () => {
+  test('reveals the correct answer via /expire when timer reaches 0', async ({ page }) => {
+    await setupLanguagesMock(page)
+    // Create the mock lazily so the expiry time is computed when the request arrives
+    await page.route('/game/translation-quiz/rounds', (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          ...mockQuizRound,
+          expiresAtUtc: new Date(Date.now() + 2_000).toISOString(),
+          roundSeconds: 2,
+        }),
+      }),
+    )
+    await setupExpireMock(page, mockQuizExpired)
+
+    await page.goto('/')
+    await openTranslationQuizTab(page)
+    await page.getByRole('button', { name: /Start Round/i }).click()
+
+    // Allow a small tolerance for client-side timer rounding; reject if called well before expiry
+    await expect(page.locator('[role="status"]')).toContainText(/Time.s up/i, { timeout: 5_000 })
+    await expect(page.getByRole('button', { name: 'Haus' })).toHaveClass(/quiz-choice-correct/, { timeout: 5_000 })
+  })
+})

--- a/source/Demo/sense-sprint-web/vite.config.ts
+++ b/source/Demo/sense-sprint-web/vite.config.ts
@@ -10,6 +10,10 @@ export default defineConfig({
         target: 'http://localhost:5000',
         changeOrigin: true,
       },
+      '/languages': {
+        target: 'http://localhost:5000',
+        changeOrigin: true,
+      },
     },
   },
 })

--- a/source/Lexicala.NET.Tests/Lexicala.NET.Tests.csproj
+++ b/source/Lexicala.NET.Tests/Lexicala.NET.Tests.csproj
@@ -67,6 +67,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Lexicala.NET\Lexicala.NET.csproj" />
+    <ProjectReference Include="..\Demo\Lexicala.NET.Demo.Api\Lexicala.NET.Demo.Api.csproj" />
   </ItemGroup>
 
 </Project>

--- a/source/Lexicala.NET.Tests/SenseSprintGameServiceTests.cs
+++ b/source/Lexicala.NET.Tests/SenseSprintGameServiceTests.cs
@@ -2,6 +2,8 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Lexicala.NET.Demo.Api.Game;
+using Lexicala.NET.Response.Entries;
+using Lexicala.NET.Response.Search;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -72,6 +74,43 @@ namespace Lexicala.NET.Client.Tests
 
             await Should.ThrowAsync<KeyNotFoundException>(() =>
                 _service.GiveUpAsync(unknownId));
+        }
+
+        [TestMethod]
+        public async Task CreateRoundAsync_ReturnsRequestedLanguage()
+        {
+            _clientMock
+                .Setup(c => c.FlukySearchAsync(It.IsAny<string>(), "de", It.IsAny<string>(), It.IsAny<System.Threading.CancellationToken>()))
+                .ReturnsAsync(new SearchResponse
+                {
+                    Results = [new Result { Id = "DE0001" }]
+                });
+
+            _clientMock
+                .Setup(c => c.GetEntryAsync("DE0001", null, It.IsAny<System.Threading.CancellationToken>()))
+                .ReturnsAsync(new Entry
+                {
+                    Id = "DE0001",
+                    HeadwordObject = new Lexicala.NET.Response.Entries.Headword
+                    {
+                        Text = "Haus",
+                        Pos = "noun"
+                    },
+                    Senses =
+                    [
+                        new Lexicala.NET.Response.Entries.Sense
+                        {
+                            Definition = "a building for human habitation",
+                            Synonyms = ["Gebaude"],
+                            Examples = [new Example { Text = "Das Haus ist gross." }]
+                        }
+                    ]
+                });
+
+            var round = await _service.CreateRoundAsync("de");
+
+            round.Language.ShouldBe("de");
+            round.Clue.ShouldNotBeNullOrWhiteSpace();
         }
     }
 }

--- a/source/Lexicala.NET.Tests/SenseSprintGameServiceTests.cs
+++ b/source/Lexicala.NET.Tests/SenseSprintGameServiceTests.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using Lexicala.NET.Demo.Api.Game;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Shouldly;
+
+namespace Lexicala.NET.Client.Tests
+{
+    [TestClass]
+    public class SenseSprintGameServiceTests
+    {
+        private IMemoryCache _cache;
+        private Mock<ILexicalaClient> _clientMock;
+        private Mock<ILogger<SenseSprintGameService>> _loggerMock;
+        private SenseSprintGameService _service;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            _cache = new MemoryCache(new MemoryCacheOptions());
+            _clientMock = new Mock<ILexicalaClient>();
+            _loggerMock = new Mock<ILogger<SenseSprintGameService>>();
+            _service = new SenseSprintGameService(_clientMock.Object, _cache, _loggerMock.Object);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            _cache.Dispose();
+        }
+
+        [TestMethod]
+        public async Task SubmitGuessAsync_NullGuess_ThrowsArgumentException()
+        {
+            await Should.ThrowAsync<ArgumentException>(() =>
+                _service.SubmitGuessAsync(Guid.NewGuid(), null!));
+        }
+
+        [TestMethod]
+        public async Task SubmitGuessAsync_WhitespaceGuess_ThrowsArgumentException()
+        {
+            await Should.ThrowAsync<ArgumentException>(() =>
+                _service.SubmitGuessAsync(Guid.NewGuid(), "   "));
+        }
+
+        [TestMethod]
+        public async Task SubmitGuessAsync_RoundNotFound_ThrowsKeyNotFoundException()
+        {
+            var unknownId = Guid.NewGuid();
+
+            await Should.ThrowAsync<KeyNotFoundException>(() =>
+                _service.SubmitGuessAsync(unknownId, "house"));
+        }
+
+        [TestMethod]
+        public async Task RevealNextClueAsync_RoundNotFound_ThrowsKeyNotFoundException()
+        {
+            var unknownId = Guid.NewGuid();
+
+            await Should.ThrowAsync<KeyNotFoundException>(() =>
+                _service.RevealNextClueAsync(unknownId));
+        }
+
+        [TestMethod]
+        public async Task GiveUpAsync_RoundNotFound_ThrowsKeyNotFoundException()
+        {
+            var unknownId = Guid.NewGuid();
+
+            await Should.ThrowAsync<KeyNotFoundException>(() =>
+                _service.GiveUpAsync(unknownId));
+        }
+    }
+}

--- a/source/Lexicala.NET.Tests/TranslationQuizGameServiceTests.cs
+++ b/source/Lexicala.NET.Tests/TranslationQuizGameServiceTests.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using System.Threading.Tasks;
+using Lexicala.NET.Demo.Api.Game;
+using Lexicala.NET.Response.Languages;
+using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Moq;
+using Shouldly;
+
+namespace Lexicala.NET.Client.Tests
+{
+    [TestClass]
+    public class TranslationQuizGameServiceTests
+    {
+        private IMemoryCache _cache;
+        private Mock<ILexicalaClient> _clientMock;
+        private Mock<ILogger<TranslationQuizGameService>> _loggerMock;
+        private TranslationQuizGameService _service;
+
+        [TestInitialize]
+        public void Initialize()
+        {
+            _cache = new MemoryCache(new MemoryCacheOptions());
+            _clientMock = new Mock<ILexicalaClient>();
+            _loggerMock = new Mock<ILogger<TranslationQuizGameService>>();
+            _service = new TranslationQuizGameService(_clientMock.Object, _cache, _loggerMock.Object);
+        }
+
+        [TestCleanup]
+        public void Cleanup()
+        {
+            _cache.Dispose();
+        }
+
+        [TestMethod]
+        public async Task CreateRoundAsync_NullLanguage_FetchesLanguagesFromApi()
+        {
+            // Arrange: language API returns a list; FlukySearch throws so round generation fails fast
+            _clientMock
+                .Setup(c => c.LanguagesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new LanguagesResponse
+                {
+                    LanguageNames = new Dictionary<string, string> { { "de", "German" }, { "nl", "Dutch" } },
+                    Resources = new Resources { Global = new Resource { SourceLanguages = ["de", "nl"] } }
+                });
+            _clientMock
+                .Setup(c => c.FlukySearchAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("API not available in test"));
+
+            // Act + Assert: null is not ArgumentException; execution reaches the mocked client
+            await Should.ThrowAsync<InvalidOperationException>(() =>
+                _service.CreateRoundAsync(null));
+
+            _clientMock.Verify(c => c.LanguagesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [TestMethod]
+        [DataRow("de")]
+        [DataRow("DE")]
+        [DataRow("nl")]
+        [DataRow("fr")]
+        [DataRow("es")]
+        [DataRow("ja")]
+        [DataRow("zh")]
+        [DataRow("xx")]
+        public async Task CreateRoundAsync_AnyLanguage_AcceptsWithoutArgumentException(string language)
+        {
+            // Arrange: make the client throw after validation so we can verify it reached the API call
+            _clientMock
+                .Setup(c => c.LanguagesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new LanguagesResponse
+                {
+                    LanguageNames = new Dictionary<string, string>(),
+                    Resources = new Resources { Global = new Resource { SourceLanguages = ["de", "nl"] } }
+                });
+            _clientMock
+                .Setup(c => c.FlukySearchAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("API not available in test"));
+
+            // Act + Assert: any language passes validation; execution reaches the mocked API call
+            await Should.ThrowAsync<InvalidOperationException>(() =>
+                _service.CreateRoundAsync(language));
+        }
+
+        [TestMethod]
+        public async Task GetTargetLanguagesAsync_CachesResult()
+        {
+            _clientMock
+                .Setup(c => c.LanguagesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new LanguagesResponse
+                {
+                    LanguageNames = new Dictionary<string, string>(),
+                    Resources = new Resources { Global = new Resource { SourceLanguages = ["de", "nl", "fr"] } }
+                });
+
+            // Call twice
+            var first = await _service.GetTargetLanguagesAsync(CancellationToken.None);
+            var second = await _service.GetTargetLanguagesAsync(CancellationToken.None);
+
+            first.ShouldBe(second);
+            _clientMock.Verify(c => c.LanguagesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        [TestMethod]
+        public async Task GetTargetLanguagesAsync_ExcludesEnglish()
+        {
+            _clientMock
+                .Setup(c => c.LanguagesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new LanguagesResponse
+                {
+                    LanguageNames = new Dictionary<string, string>(),
+                    Resources = new Resources { Global = new Resource { SourceLanguages = ["en", "de", "nl"] } }
+                });
+
+            var languages = await _service.GetTargetLanguagesAsync(CancellationToken.None);
+
+            languages.ShouldNotContain("en");
+            languages.ShouldContain("de");
+            languages.ShouldContain("nl");
+        }
+
+        [TestMethod]
+        public async Task GetTargetLanguagesAsync_PrefersTargetLanguagesOverSourceLanguages()
+        {
+            _clientMock
+                .Setup(c => c.LanguagesAsync(It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new LanguagesResponse
+                {
+                    LanguageNames = new Dictionary<string, string>(),
+                    Resources = new Resources
+                    {
+                        Global = new Resource
+                        {
+                            SourceLanguages = ["en", "de", "nl"],
+                            TargetLanguages = ["de", "fr"]
+                        }
+                    }
+                });
+
+            var languages = await _service.GetTargetLanguagesAsync(CancellationToken.None);
+
+            languages.ShouldContain("de");
+            languages.ShouldContain("fr");
+            languages.ShouldNotContain("nl"); // only in source, not target
+        }
+
+        [TestMethod]
+        public async Task GetTargetLanguagesAsync_FallsBackOnApiError()
+        {
+            _clientMock
+                .Setup(c => c.LanguagesAsync(It.IsAny<CancellationToken>()))
+                .ThrowsAsync(new InvalidOperationException("API error"));
+
+            var languages = await _service.GetTargetLanguagesAsync(CancellationToken.None);
+
+            languages.ShouldNotBeEmpty();
+        }
+
+        [TestMethod]
+        public async Task SubmitAnswerAsync_RoundNotFound_ThrowsKeyNotFoundException()
+        {
+            var unknownId = Guid.NewGuid();
+
+            await Should.ThrowAsync<KeyNotFoundException>(() =>
+                _service.SubmitAnswerAsync(unknownId, "someChoice"));
+        }
+
+        [TestMethod]
+        public async Task SubmitAnswerAsync_NullChoice_ThrowsArgumentException()
+        {
+            await Should.ThrowAsync<ArgumentException>(() =>
+                _service.SubmitAnswerAsync(Guid.NewGuid(), null!));
+        }
+
+        [TestMethod]
+        public async Task SubmitAnswerAsync_EmptyChoice_ThrowsArgumentException()
+        {
+            await Should.ThrowAsync<ArgumentException>(() =>
+                _service.SubmitAnswerAsync(Guid.NewGuid(), string.Empty));
+        }
+
+        [TestMethod]
+        public async Task ExpireRoundAsync_RoundNotFound_ThrowsKeyNotFoundException()
+        {
+            var unknownId = Guid.NewGuid();
+
+            await Should.ThrowAsync<KeyNotFoundException>(() =>
+                _service.ExpireRoundAsync(unknownId));
+        }
+    }
+}

--- a/source/Lexicala.NET.Tests/TranslationQuizGameServiceTests.cs
+++ b/source/Lexicala.NET.Tests/TranslationQuizGameServiceTests.cs
@@ -3,7 +3,9 @@ using System.Collections.Generic;
 using System.Threading;
 using System.Threading.Tasks;
 using Lexicala.NET.Demo.Api.Game;
+using Lexicala.NET.Response.Entries;
 using Lexicala.NET.Response.Languages;
+using Lexicala.NET.Response.Search;
 using Microsoft.Extensions.Caching.Memory;
 using Microsoft.Extensions.Logging;
 using Microsoft.VisualStudio.TestTools.UnitTesting;
@@ -160,6 +162,53 @@ namespace Lexicala.NET.Client.Tests
         }
 
         [TestMethod]
+        public async Task CreateRoundAsync_ReusesCachedDistractors_ForSameTargetLanguage()
+        {
+            _clientMock
+                .Setup(c => c.GetEntryAsync("EN0001", null, It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new Entry
+                {
+                    Id = "EN0001",
+                    HeadwordObject = new Lexicala.NET.Response.Entries.Headword { Text = "house" },
+                    Senses =
+                    [
+                        new Lexicala.NET.Response.Entries.Sense
+                        {
+                            Translations = new Dictionary<string, TranslationObject>
+                            {
+                                ["de"] = new Translation { Text = "Haus" }
+                            }
+                        }
+                    ]
+                });
+
+            _clientMock
+                .Setup(c => c.FlukySearchAsync(It.IsAny<string>(), "en", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(new SearchResponse
+                {
+                    Results = [new Result { Id = "EN0001" }]
+                });
+
+            var distractorResponses = new Queue<SearchResponse>(
+            [
+                BuildDistractorResponse("Auto"),
+                BuildDistractorResponse("Baum"),
+                BuildDistractorResponse("Buch")
+            ]);
+
+            _clientMock
+                .Setup(c => c.FlukySearchAsync(It.IsAny<string>(), "de", It.IsAny<string>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(() => distractorResponses.Dequeue());
+
+            var firstRound = await _service.CreateRoundAsync("de", CancellationToken.None);
+            var secondRound = await _service.CreateRoundAsync("de", CancellationToken.None);
+
+            firstRound.Choices.Length.ShouldBe(4);
+            secondRound.Choices.Length.ShouldBe(4);
+            _clientMock.Verify(c => c.FlukySearchAsync(It.IsAny<string>(), "de", It.IsAny<string>(), It.IsAny<CancellationToken>()), Times.Exactly(3));
+        }
+
+        [TestMethod]
         public async Task SubmitAnswerAsync_RoundNotFound_ThrowsKeyNotFoundException()
         {
             var unknownId = Guid.NewGuid();
@@ -189,6 +238,21 @@ namespace Lexicala.NET.Client.Tests
 
             await Should.ThrowAsync<KeyNotFoundException>(() =>
                 _service.ExpireRoundAsync(unknownId));
+        }
+
+        private static SearchResponse BuildDistractorResponse(string headword)
+        {
+            return new SearchResponse
+            {
+                Results =
+                [
+                    new Result
+                    {
+                        Id = headword,
+                        Headword = new Lexicala.NET.Response.Search.Headword { Text = headword }
+                    }
+                ]
+            };
         }
     }
 }


### PR DESCRIPTION
This pull request introduces several improvements and new features to the Lexicala.NET demo projects, with a focus on expanding and documenting the Sense Sprint demo game and adding support for a new Translation Quiz game mode. The changes include enhancements to API contracts, service interfaces, and documentation to support language selection, improved round management, and clearer development instructions.

**Key changes:**

### Demo Game Enhancements

* Added a new React + TypeScript + Vite demo game (`sense-sprint-web`) under `source/Demo/`, with updated documentation and clearer instructions for setup and usage in both the `.github/instructions/repository-information.instructions.md` and `README.md` files. [[1]](diffhunk://#diff-53566e28545b991f95ce0d9a161deb8d9ef15a83ed2d50a04877632af8eca8f9R17-R26) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L244-R293)
* Updated the Sense Sprint API and frontend documentation to reflect support for multiple languages and to provide links to detailed game documentation. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L216-R237) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L235-R254)

### Sense Sprint Game Service Improvements

* Modified the `ISenseSprintGameService` and `SenseSprintGameService` to support creating rounds in a user-selected language (defaulting to English if none is provided), and updated the round creation flow to include the language in the response. [[1]](diffhunk://#diff-c07f8898fba2c901c83d813085613363c51052b4d2f2c87df321274a07f4825eL9-R9) [[2]](diffhunk://#diff-ba024029e73c1daf7638ab5bf7295ccac7f0eedd8d29b4c0424f5632d37b79a2R7) [[3]](diffhunk://#diff-4e115cba11110361ded582acabc6978bae682d5017c114f4535b3704542b5fe7L35-R42) [[4]](diffhunk://#diff-4e115cba11110361ded582acabc6978bae682d5017c114f4535b3704542b5fe7R54) [[5]](diffhunk://#diff-4e115cba11110361ded582acabc6978bae682d5017c114f4535b3704542b5fe7R223-R235) [[6]](diffhunk://#diff-4e115cba11110361ded582acabc6978bae682d5017c114f4535b3704542b5fe7R347-R348)
* Improved the `GiveUpAsync` method to distinguish between expired and lost rounds, providing more accurate feedback to the user.
* Refactored rate limit extraction logic into a reusable helper (`GameServiceHelpers`). [[1]](diffhunk://#diff-81f9b8e9d9c801a225499f9a0a030adb47b4d1ef02d90b7a1ccaab5ad06ccfecR1-R22) [[2]](diffhunk://#diff-4e115cba11110361ded582acabc6978bae682d5017c114f4535b3704542b5fe7R223-R235)

### Translation Quiz Game Mode

* Introduced a new `ITranslationQuizGameService` interface and related API contracts (`TranslationQuizContracts.cs`) to support a translation quiz game mode, including round creation, answer submission, and round expiration. [[1]](diffhunk://#diff-d2aa2e82994d118e3d9be7a1859d3ea15b67c6b249a3b1f2cef7c9fee385b42dR1-R14) [[2]](diffhunk://#diff-a1e64b224e86dc365ffc1f65b08dfabe8dc4435631e0483408541e5f1f70aaa5R1-R25)

### Documentation and Developer Experience

* Expanded the repository documentation to include setup steps for API keys, clearer instructions for running both backend and frontend demos, and updated endpoint descriptions to reflect new and changed features. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L206-R227) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L244-R293)
* Clarified project structure and the purpose of demonstration projects in `.github/instructions/repository-information.instructions.md`.

These changes collectively improve the flexibility, usability, and documentation of the demo projects, making it easier for developers to run, extend, and understand the Sense Sprint and Translation Quiz games.